### PR TITLE
sysfs field `command` missing on doc page lego-sensor-class

### DIFF
--- a/sensors/lego_sensor_class.c
+++ b/sensors/lego_sensor_class.c
@@ -69,6 +69,7 @@
  * .    - `s16_be`: Signed 16-bit integer, big endian
  * .    - `s32`: Signed 32-bit integer (int)
  * .    - `float`: IEEE 754 32-bit floating point (float)
+ * .
  * `command` (write-only)
  * : Sends a command to the sensor.
  * .


### PR DESCRIPTION
Not sure if this is the correct fix:
Added a line before the `command` field:

```
* .
```

like I see before the other fields.
