### PR TITLE
Fix typo in ev3_tacho_motor.c

### DIFF
--- a/motors/ev3_tacho_motor.c
+++ b/motors/ev3_tacho_motor.c
@@ -32,7 +32,7 @@
  * `/sys/bus/lego/drivers/ev3-tacho-motor /`. There is not much of interest
  * there though - all of the useful stuff is in the [tacho-motor] class.
  * .
- * [tacho-motor]: ../taco-motor-class
+ * [tacho-motor]: ../tacho-motor-class
  * [incremental rotary encoder]: https://en.wikipedia.org/wiki/Rotary_encoder#Incremental_rotary_encoder
  */
 


### PR DESCRIPTION
The link was spelled like "taco" (food) instead of "tacho" ("tachometer").
