### PR TITLE
Fix incorrect 'driver_name' attribute values for EV3 UART sensors

### DIFF
--- a/sensors/ev3_uart_sensor.h
+++ b/sensors/ev3_uart_sensor.h
@@ -18,6 +18,8 @@
 
 #include <lego_sensor_class.h>
 
+#define EV3_UART_SENSOR_NAME(type_id) "lego-ev3-uart-" type_id
+
 /**
  * struct ev3_uart_sensor_info
  * @name: The driver name. Must match name in id_table.

--- a/sensors/ev3_uart_sensor_core.c
+++ b/sensors/ev3_uart_sensor_core.c
@@ -131,10 +131,10 @@ static int ev3_uart_sensor_remove(struct lego_device *ldev)
 }
 
 static const struct lego_device_id ev3_uart_sensor_device_ids[] = {
-	{ "lego-ev3-uart-29",	LEGO_EV3_COLOR		},
-	{ "lego-ev3-uart-30",	LEGO_EV3_ULTRASONIC	},
-	{ "lego-ev3-uart-32",	LEGO_EV3_GYRO		},
-	{ "lego-ev3-uart-33",	LEGO_EV3_INFRARED	},
+	{ EV3_UART_SENSOR_NAME("29"),	LEGO_EV3_COLOR		},
+	{ EV3_UART_SENSOR_NAME("30"),	LEGO_EV3_ULTRASONIC	},
+	{ EV3_UART_SENSOR_NAME("32"),	LEGO_EV3_GYRO		},
+	{ EV3_UART_SENSOR_NAME("33"),	LEGO_EV3_INFRARED	},
 };
 
 struct lego_device_driver ev3_uart_sensor_driver = {

--- a/sensors/ev3_uart_sensor_defs.c
+++ b/sensors/ev3_uart_sensor_defs.c
@@ -29,7 +29,7 @@ const struct ev3_uart_sensor_info ev3_uart_sensor_defs[] = {
 		 * @vendor_part_number: 45506
 		 * @vendor_part_name: EV3 Color Sensor
 		 */
-		.name		= "lego-ev3-uart-29",
+		.name		= EV3_UART_SENSOR_NAME("29"),
 		.num_modes	= 6,
 		.num_view_modes	= 3,
 		.mode_info	= {
@@ -127,7 +127,7 @@ const struct ev3_uart_sensor_info ev3_uart_sensor_defs[] = {
 		 * @vendor_part_number: 45504
 		 * @vendor_part_name: EV3 Ultrasonic Sensor
 		 */
-		.name		= "lego-ev3-uart-30",
+		.name		= EV3_UART_SENSOR_NAME("30"),
 		.num_modes	= 5,
 		.num_view_modes	= 3,
 		.mode_info	= {
@@ -240,7 +240,7 @@ const struct ev3_uart_sensor_info ev3_uart_sensor_defs[] = {
 		 * @vendor_part_number: 45505
 		 * @vendor_part_name: EV3 Gyro Sensor
 		 */
-		.name		= "lego-ev3-uart-32",
+		.name		= EV3_UART_SENSOR_NAME("32"),
 		.num_modes	= 5,
 		.num_view_modes	= 3,
 		.mode_info	= {
@@ -326,7 +326,7 @@ const struct ev3_uart_sensor_info ev3_uart_sensor_defs[] = {
 		 * @vendor_part_number: 45509
 		 * @vendor_part_name: EV3 Infrared Sensor
 		 */
-		.name		= "lego-ev3-uart-33",
+		.name		= EV3_UART_SENSOR_NAME("33"),
 		.num_modes	= 6,
 		.num_view_modes	= 3,
 		.mode_info	= {

--- a/sensors/ev3_uart_sensor_ld.c
+++ b/sensors/ev3_uart_sensor_ld.c
@@ -40,7 +40,7 @@
  * sensors. Instead, all of the needed info to sent from the sensor in a common
  * format.  As a result, the name returned by the [lego-sensor][lego-sensor
  * class] `device_name` attribute is not a real driver name. Instead it returns
- * `ev3-uart-<N>`, where `<N>` is the type id of the sensor.
+ * `lego-ev3-uart-<N>`, where `<N>` is the type id of the sensor.
  * .
  * [line discipline]: https://en.wikipedia.org/wiki/Line_discipline
  * [lego-sensor class]: ../lego-sensor-class
@@ -60,6 +60,8 @@
 #include <lego.h>
 #include <lego_port_class.h>
 #include <lego_sensor_class.h>
+
+#include "ev3_uart_sensor.h"
 
 #ifdef DEBUG
 #define debug_pr(fmt, ...) printk(fmt, ##__VA_ARGS__)
@@ -516,7 +518,7 @@ static void ev3_uart_handle_rx_data(struct work_struct *work)
 		for (i = 0; i <= EV3_UART_MODE_MAX; i++)
 			port->mode_info[i] = ev3_uart_default_mode_info;
 		port->type_id = type;
-		snprintf(port->device_name, LEGO_SENSOR_NAME_SIZE, "ev3-uart-%u", type);
+		snprintf(port->device_name, LEGO_SENSOR_NAME_SIZE, EV3_UART_SENSOR_NAME("%u"), type);
 		port->info_flags = EV3_UART_INFO_FLAG_CMD_TYPE;
 		port->synced = 1;
 		port->info_done = 0;

--- a/sensors/ms_ev3_smux.c
+++ b/sensors/ms_ev3_smux.c
@@ -22,6 +22,7 @@
 #include <lego.h>
 #include <lego_port_class.h>
 
+#include "ev3_uart_sensor.h"
 #include "ms_ev3_smux.h"
 
 enum ms_ev3_smux_mode {
@@ -78,10 +79,10 @@ static const struct lego_port_mode_info ms_ev3_smux_port_mode_info[] = {
 };
 
 static const char *ms_ev3_smux_uart_sensor_names[] = {
-	"lego-ev3-uart-29", /* Color      */
-	"lego-ev3-uart-30", /* Ultrasonic */
-	"lego-ev3-uart-32", /* Gyro       */
-	"lego-ev3-uart-33", /* Infrared   */
+	EV3_UART_SENSOR_NAME("29"), /* Color      */
+	EV3_UART_SENSOR_NAME("30"), /* Ultrasonic */
+	EV3_UART_SENSOR_NAME("32"), /* Gyro       */
+	EV3_UART_SENSOR_NAME("33"), /* Infrared   */
 	NULL
 };
 

--- a/sensors/nxt_i2c_sensor_defs.c
+++ b/sensors/nxt_i2c_sensor_defs.c
@@ -1489,7 +1489,7 @@ const struct nxt_i2c_sensor_info nxt_i2c_sensor_defs[] = {
 		 * on the servo controller itself.
 		 * .
 		 * [lego-sensor class]: /docs/drivers/lego-sensor-class
-		 * [servo-motor class]: /docs/motors/servo-motor-class
+		 * [servo-motor class]: /docs/drivers/servo-motor-class
 		 *
 		 * @vendor_name: mindsensors.com
 		 * @vendor_part_number: NxtServo


### PR DESCRIPTION
Also `EV3_UART_SENSOR_NAME(suffix)` macros has been added into `ev3_uart_sensor.h`.