### PR TITLE
part number of PF_M_MOTOR typo in motor doc

### DIFF
--- a/motors/rcx_motor_defs.c
+++ b/motors/rcx_motor_defs.c
@@ -35,7 +35,7 @@ const struct rcx_motor_info rcx_motor_defs[] = {
 	[LEGO_PF_M_MOTOR] = {
 		/**
 		 * @vendor_name: LEGO
-		 * @vendor_part_number: 9842
+		 * @vendor_part_number: 8883
 		 * @vendor_part_name: Power Functions M-Motor
 		 * @vendor_website: http://shop.lego.com/en-US/LEGO-Power-Functions-M-Motor-8883
 		 */


### PR DESCRIPTION
Probably copied and forgot to change (from NXT motor)