### PR TITLE
Finish initial support for text_value

### DIFF
--- a/include/lego_sensor_class.h
+++ b/include/lego_sensor_class.h
@@ -2,6 +2,7 @@
  * LEGO sensor device class
  *
  * Copyright (C) 2014-2015 David Lechner <david@lechnology.com>
+ * Copyright (C) 2015-     Ralph Hempel <rhempel@hempeldesigngroup.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2 as
@@ -106,6 +107,7 @@ struct lego_sensor_cmd_info {
  * @get_poll_ms: Get the polling period in milliseconds (optional).
  * @set_poll_ms: Set the polling period in milliseconds (optional).
  * @context: Pointer to data structure used by callbacks.
+ * @get_text_value: Get the text value for the sensor (optional).
  * @fw_version: Firmware version of sensor (optional).
  * @dev: The device data structure.
  */
@@ -124,6 +126,7 @@ struct lego_sensor_device {
 	ssize_t (*direct_write)(void *context, char *data, loff_t off, size_t count);
 	int (* get_poll_ms)(void *context);
 	int (* set_poll_ms)(void *context, unsigned value);
+	const char *(*get_text_value)(void *context);
 	void *context;
 	char fw_version[LEGO_SENSOR_FW_VERSION_SIZE + 1];
 	/* private */

--- a/sensors/lego_sensor_class.c
+++ b/sensors/lego_sensor_class.c
@@ -125,7 +125,6 @@
  * .
  * `text_value` (read-only)
  * : Returns a space delimited string representing sensor-specific text values.
- *   Currently the string is limited to 512 bytes.
  * .
  * ### Events
  * .

--- a/sensors/lego_sensor_class.c
+++ b/sensors/lego_sensor_class.c
@@ -2,6 +2,7 @@
  * LEGO sensor device class
  *
  * Copyright (C) 2013-2015 David Lechner <david@lechnology.com>
+ * Copyright (C) 2015      Ralph Hempel <rhempel@hempeldesigngroup.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2 as
@@ -121,6 +122,12 @@
  *   see how many values there are. Values with N >= num_values will return an
  *   error. The values are fixed point numbers, so check `decimals` to see if
  *   you need to divide to get the actual value.
+ * .
+ * `text_value` (read-only)
+ * : Returns a string representing sensor-specific text value. The string
+ *   contains space delimited values, is null terminated, and is limited
+ *   to PAGE_SIZE-2 bytes to take into account the NULL terminator. We force
+ *   a trailing linefeed on the return value.
  * .
  * ### Events
  * .
@@ -511,6 +518,24 @@ static ssize_t fw_version_show(struct device *dev, struct device_attribute *attr
 	return snprintf(buf, LEGO_SENSOR_FW_VERSION_SIZE + 2, "%s\n", sensor->fw_version);
 }
 
+static ssize_t text_value_show(struct device *dev, struct device_attribute *attr,
+			      char *buf)
+{
+	struct lego_sensor_device *sensor = to_lego_sensor_device(dev);
+	const char *value;
+ 
+	if (!sensor->get_text_value)
+		return -EOPNOTSUPP;
+ 
+	value = sensor->get_text_value(sensor->context);
+
+	if(IS_ERR(value))
+		return PTR_ERR(value);
+
+	return snprintf(buf, PAGE_SIZE, "%s\n", value);
+}
+
+
 static ssize_t bin_data_read(struct file *file, struct kobject *kobj,
 			     struct bin_attribute *attr,
 			     char *buf, loff_t off, size_t count)
@@ -567,6 +592,7 @@ static DEVICE_ATTR_RO(units);
 static DEVICE_ATTR_RO(decimals);
 static DEVICE_ATTR_RO(num_values);
 static DEVICE_ATTR_RO(bin_data_format);
+static DEVICE_ATTR_RO(text_value);
 /*
  * Technically, it is possible to have 32 8-bit values from UART sensors
  * and >200 8-bit values from I2C sensors, but known UART sensors so far
@@ -596,6 +622,7 @@ static struct attribute *lego_sensor_class_attrs[] = {
 	&dev_attr_decimals.attr,
 	&dev_attr_num_values.attr,
 	&dev_attr_bin_data_format.attr,
+	&dev_attr_text_value.attr,
 	&dev_attr_value0.attr,
 	&dev_attr_value1.attr,
 	&dev_attr_value2.attr,

--- a/sensors/lego_sensor_class.c
+++ b/sensors/lego_sensor_class.c
@@ -124,10 +124,8 @@
  *   you need to divide to get the actual value.
  * .
  * `text_value` (read-only)
- * : Returns a string representing sensor-specific text value. The string
- *   contains space delimited values, is null terminated, and is limited
- *   to PAGE_SIZE-2 bytes to take into account the NULL terminator. We force
- *   a trailing linefeed on the return value.
+ * : Returns a space delimited string representing sensor-specific text values.
+ *   Currently the string is limited to 512 bytes.
  * .
  * ### Events
  * .

--- a/user/user_lego_sensor.c
+++ b/user/user_lego_sensor.c
@@ -63,10 +63,20 @@ static ssize_t address_show(struct device *dev, struct device_attribute *attr,
 	return snprintf(buf, LEGO_NAME_SIZE, "%s\n", sensor->sensor.address);
 }
 
+static ssize_t text_value_store(struct device *dev, struct device_attribute *attr,
+			        const char *buf, size_t count)
+{
+ 	struct user_lego_sensor_device *sensor = to_user_lego_sensor_device(dev);
+ 
+	return snprintf( sensor->text_value, USER_LEGO_SENSOR_TEXT_VALUE_SIZE, buf );
+}
+
 static DEVICE_ATTR_RO(address);
+static DEVICE_ATTR_WO(text_value);
 
 static struct attribute *user_lego_sensor_class_attrs[] = {
 	&dev_attr_address.attr,
+	&dev_attr_text_value.attr,
 	NULL
 };
 
@@ -107,6 +117,12 @@ static const struct attribute_group *user_lego_sensor_class_groups[] = {
 	NULL
 };
 
+const char *user_lego_sensor_get_text_value(void *context) {
+	struct user_lego_sensor_device *sensor = context;
+
+        return sensor->text_value;
+}
+ 
 static void user_lego_sensor_release(struct device *dev)
 {
 }
@@ -137,6 +153,9 @@ int user_lego_sensor_register(struct user_lego_sensor_device *sensor,
 
 	dev_info(&sensor->dev, "Registered '%s' on '%s'.\n", sensor->sensor.name,
 		 sensor->sensor.address);
+
+	sensor->sensor.context = sensor; 
+        sensor->sensor.get_text_value = user_lego_sensor_get_text_value;
 
 	err = register_lego_sensor(&sensor->sensor, &sensor->dev);
 	if (err) {

--- a/user/user_lego_sensor.c
+++ b/user/user_lego_sensor.c
@@ -46,8 +46,8 @@
  * .
  * `text_value` (write-only)
  * : The written data will be stored and can be read using the corresponding
- *   `text_value` attribute in the `lego-sensor` class device.
-
+ *   `text_value` attribute in the `lego-sensor` class device. It is currently
+ *   limited to 512 bytes in length.
  */
 
 #include <linux/device.h>
@@ -79,7 +79,7 @@ static ssize_t text_value_store(struct device *dev, struct device_attribute *att
 	snprintf(sensor->text_value, USER_LEGO_SENSOR_TEXT_VALUE_SIZE, "%s", buf);
 
 	if (sensor->text_value[count-1] == '\n')
-		(sensor->text_value[count-1] = '\0');
+		sensor->text_value[count-1] = '\0';
 
 	return count;
 }

--- a/user/user_lego_sensor.h
+++ b/user/user_lego_sensor.h
@@ -16,18 +16,12 @@
 #include <lego.h>
 #include <lego_sensor_class.h>
 
-/* The USER_LEGO_SENSOR_TEXT_VALUE_SIZE can be a maximum of PAGE_SIZE-2
- * to take into account a trailing newline (added later) and NULL. We are
- * limiting it to much less to save memory for each user_lego_sensor 
- * instance.
- */
-
-#define USER_LEGO_SENSOR_TEXT_VALUE_SIZE (512-2)
+#define USER_LEGO_SENSOR_TEXT_VALUE_SIZE 512
 
 struct user_lego_sensor_device {
 	struct lego_sensor_device sensor;
 	struct device dev;
-        char text_value[USER_LEGO_SENSOR_TEXT_VALUE_SIZE];
+	char text_value[USER_LEGO_SENSOR_TEXT_VALUE_SIZE+1];
 };
 
 extern int user_lego_sensor_register(struct user_lego_sensor_device *sensor,

--- a/user/user_lego_sensor.h
+++ b/user/user_lego_sensor.h
@@ -16,9 +16,18 @@
 #include <lego.h>
 #include <lego_sensor_class.h>
 
+/* The USER_LEGO_SENSOR_TEXT_VALUE_SIZE can be a maximum of PAGE_SIZE-2
+ * to take into account a trailing newline (added later) and NULL. We are
+ * limiting it to much less to save memory for each user_lego_sensor 
+ * instance.
+ */
+
+#define USER_LEGO_SENSOR_TEXT_VALUE_SIZE (512-2)
+
 struct user_lego_sensor_device {
 	struct lego_sensor_device sensor;
 	struct device dev;
+        char text_value[USER_LEGO_SENSOR_TEXT_VALUE_SIZE];
 };
 
 extern int user_lego_sensor_register(struct user_lego_sensor_device *sensor,


### PR DESCRIPTION
Added code per changes discussed earlier. I left the initial copy operation using `snprintf()` to handle the case of the echo passing in a non-terminated string (just in case)

Interestingly, you cannot write to a sysfs text attribute a string with embedded linefeeds - the kernel will break it into multiple writes and only the last string will stick.

We may be able to take advantage of that later when we do a framebuffer daemon (maybe)

