### PR TITLE
Doc update only: mode "rcx-led" should be "led

### DIFF
--- a/motors/rcx_led.c
+++ b/motors/rcx_led.c
@@ -31,7 +31,7 @@
  * There is not much of interest there though - all the useful stuff is in the
  * [leds] class.
  * .
- * This device is loaded when an [ev3-output-port] is set to `rcx-led` mode.
+ * This device is loaded when an [ev3-output-port] is set to `led` mode.
  * It is not automatically detected.
  * .
  * [leds]: https://github.com/ev3dev/ev3dev/wiki/Using-the-LEDs


### PR DESCRIPTION
The mode can be `auto tacho-motor dc-motor led raw` not `rcx-led`