### PR TITLE
Add NXT Temperature Sensor support

### DIFF
--- a/sensors/nxt_i2c_sensor.h
+++ b/sensors/nxt_i2c_sensor.h
@@ -125,6 +125,7 @@ struct nxt_i2c_sensor_info {
 
 enum nxt_i2c_sensor_type {
 	LEGO_NXT_ULTRASONIC_SENSOR,
+	LEGO_NXT_TEMPERATURE_SENSOR,
 	LEGO_POWER_STORAGE_SENSOR,
 	HT_NXT_PIR_SENSOR,
 	HT_NXT_BAROMETRIC_SENSOR,
@@ -158,6 +159,7 @@ enum nxt_i2c_sensor_type {
  * termination, so no more than 18 chars here!
  */
 #define LEGO_NXT_ULTRASONIC_SENSOR_NAME		"lego-nxt-us"
+#define LEGO_NXT_TEMPERATURE_SENSOR_NAME	"lego-nxt-temp"
 #define LEGO_POWER_STORAGE_SENSOR_NAME		"lego-power-storage"
 #define HT_NXT_PIR_SENSOR_NAME			"ht-nxt-pir"
 #define HT_NXT_BAROMETRIC_SENSOR_NAME		"ht-nxt-barometric"
@@ -191,6 +193,7 @@ enum nxt_i2c_sensor_type {
  */
 #define NXT_I2C_SENSOR_ID_TABLE_DATA				\
 	LEGO_DEVICE_ID(LEGO_NXT_ULTRASONIC_SENSOR),		\
+	LEGO_DEVICE_ID(LEGO_NXT_TEMPERATURE_SENSOR),		\
 	LEGO_DEVICE_ID(LEGO_POWER_STORAGE_SENSOR),		\
 	LEGO_DEVICE_ID(HT_NXT_PIR_SENSOR),			\
 	LEGO_DEVICE_ID(HT_NXT_BAROMETRIC_SENSOR),		\

--- a/sensors/nxt_i2c_sensor_defs.c
+++ b/sensors/nxt_i2c_sensor_defs.c
@@ -446,6 +446,63 @@ const struct nxt_i2c_sensor_info nxt_i2c_sensor_defs[] = {
 			},
 		},
 	},
+	[LEGO_NXT_TEMPERATURE_SENSOR] = {
+		/**
+		 * @vendor_name: LEGO
+		 * @vendor_part_number: 9749
+		 * @vendor_part_name: MINDSTORMS Temperature Sensor
+		 * @vendor_website: https://education.lego.com/en-us/products/mindstorms-temperature-sensor/9749
+		 * @default_address: 0x4C
+		 */
+		.name		= LEGO_NXT_TEMPERATURE_SENSOR_NAME,
+		.vendor_id	= "LEGO",
+		.product_id	= "Temp.",
+		.num_modes	= 2,
+		.mode_info	= (const struct lego_sensor_mode_info[]) {
+			[0] = {
+				/**
+				 * @description: Continuous measurement
+				 * @value0: Temperature (-55.0 to 128.0)
+				 * @units_description: °C
+				 */
+				.name	= "NXT-TEMP-C",
+				.units	= "C",
+				.raw_min = -14080,
+				.raw_max = 32767,
+				.si_min = -550,
+				.si_max = 1280,
+				.decimals = 1,
+				.data_type = LEGO_SENSOR_DATA_S16_BE,
+			},
+			[1] = {
+				/**
+				 * @description: Continuous measurement
+				 * @value0: Temperature (-67.0 to 262.4)
+				 * @units_description: °F
+				 */
+				.name	= "NXT-TEMP-F",
+				.units	= "F",
+				.raw_min = -14080,
+				.raw_max = 32767,
+				.si_min = -670,
+				.si_max = 2624,
+				.decimals = 1,
+				.data_type = LEGO_SENSOR_DATA_S16_BE,
+			}
+		},
+		.i2c_mode_info	= (const struct nxt_i2c_sensor_mode_info[]) {
+			[0] = {
+				.set_mode_reg	= 0x01,
+				.set_mode_data	= 0x60,
+				.read_data_reg	= 0x00,
+			},
+			[1] = {
+				.set_mode_reg	= 0x01,
+				.set_mode_data	= 0x60,
+				.read_data_reg	= 0x00,
+			},
+		},
+	},
 	[LEGO_POWER_STORAGE_SENSOR] = {
 		/**
 		 * @vendor_name: LEGO

--- a/sensors/other_sensor_defs.c
+++ b/sensors/other_sensor_defs.c
@@ -25,40 +25,6 @@
  * parser can be found in the ev3dev-kpkg repository.
  */
 
-const struct other_sensor_info lm75_defs[] = {
-	[LEGO_NXT_TEMPERATURE_SENSOR] = {
-		/**
-		 * [^addresses]: Valid addresses are 0x48..0x4F (configurable via input pins)
-		 * [^usage]: Sample usage:
-		 *
-		 * Register I2C device:
-		 *
-		 * <pre><code>echo tmp275 0x4C > /sys/bus/i2c/devices/i2c-<port+2>/new_device
-		 * </code></pre>
-		 *
-		 * Finding device class node:
-		 *
-		 * <pre><code>for chip in $(find /sys/class/hwmon -name hwmon*)
-		 * do
-		 *     if [[ "$(cat $chip/device/name)" == "tmp275" ]]
-		 *     then
-		 *         # do whatever
-		 *     fi
-		 * done
-		 * </code></pre>
-		 *
-		 * @vendor_name: LEGO
-		 * @vendor_part_number: 9749
-		 * @vendor_part_name: NXT Temperature Sensor
-		 * @vendor_website: http://education.lego.com/en-us/lego-education-product-database/mindstorms/9749-nxt-temperature-sensor/
-		 * @device_class: [hwmon](https://wiki.archlinux.org/index.php/Lm_sensors) [^usage]
-		 * @default_address: 0x4C
-		 * @default_address_footnote: [^addresses]
-		 */
-		.name		= "tmp275",
-	},
-};
-
 const struct other_sensor_info gpio_pcf857xr_defs[] = {
 	[MS_SENSOR_KIT_PFC8574] = {
 		/**


### PR DESCRIPTION
@dlech Please take a look. No testing yet, since I'm wanting to make sure it will be safe before I do.

I don't think this is quite right - the scaling looks to me like I should not need to do what I am doing, but the raw_min and raw_max are u32 and I need negative values. Hence the approach I'm taking.

I'm also not sure about how mode state is retained - the device has a variety of modes (word width and one-shot v continuous), but (sanely) imperial is not supported, so unit mode state needs to be retained somewhere else - I am assuming the lego sensor module handles that, but I can't find any indication of that.

Anyway, when you have time please make some suggestions.