### PR TITLE
Update lego_port_class.c

### DIFF
--- a/core/lego_port_class.c
+++ b/core/lego_port_class.c
@@ -74,7 +74,7 @@
  * : (write-only) For modes that support it, writing the name of a driver will
  *   cause a new device to be registered for that driver and attached to this
  *   port. For example, since NXT/Analog sensors cannot be auto-detected, you
- *   must use this attribute to load the correct driver. Returns `-EOPNOTSUPP`
+ *   must use this attribute to load the correct driver (as also the I2C address). Returns `-EOPNOTSUPP`
  *   if setting a device is not supported.
  * .
  * `status`

--- a/core/lego_port_class.c
+++ b/core/lego_port_class.c
@@ -74,8 +74,8 @@
  * : (write-only) For modes that support it, writing the name of a driver will
  *   cause a new device to be registered for that driver and attached to this
  *   port. For example, since NXT/Analog sensors cannot be auto-detected, you
- *   must use this attribute to load the correct driver (as also the I2C address). Returns `-EOPNOTSUPP`
- *   if setting a device is not supported.
+ *   must use this attribute to load the correct driver (and also the I2C
+ *   address). Returns `-EOPNOTSUPP` * if setting a device is not supported.
  * .
  * `status`
  * : (read-only) In most cases, reading status will return the same value as

--- a/core/lego_port_class.c
+++ b/core/lego_port_class.c
@@ -75,7 +75,7 @@
  *   cause a new device to be registered for that driver and attached to this
  *   port. For example, since NXT/Analog sensors cannot be auto-detected, you
  *   must use this attribute to load the correct driver (and also the I2C
- *   address). Returns `-EOPNOTSUPP` * if setting a device is not supported.
+ *   address). Returns `-EOPNOTSUPP` if setting a device is not supported.
  * .
  * `status`
  * : (read-only) In most cases, reading status will return the same value as


### PR DESCRIPTION
Add a note to also use I2C  address with set_device attribute for NXT sensors.