### PR TITLE
CI: ignore extra header lines added by GitHub

### DIFF
--- a/checkpatch.sh
+++ b/checkpatch.sh
@@ -21,6 +21,7 @@ else
         exit 0
     fi
     curl -i "https://github.com/$TRAVIS_REPO_SLUG/compare/ev3dev:master...$TRAVIS_COMMIT.diff" \
+        | grep -v '\(^X-Served-By:\|^X-Request-Id:\|^Set-Cookie:\|^Content-Security-Policy:\|^Public-Key-Pins:\)' \
         | $check_patch --no-tree --no-signoff --ignore BAD_SIGN_OFF -
 fi
 

--- a/checkpatch.sh
+++ b/checkpatch.sh
@@ -12,6 +12,10 @@ else
     check_patch=./checkpatch.pl
 fi
 
+if [ ! -f "spelling.txt" ]; then
+        wget https://raw.githubusercontent.com/ev3dev/ev3-kernel/ev3dev-jessie/scripts/spelling.txt
+    fi
+
 if [ -z "$TRAVIS_REPO_SLUG" ]; then
     git diff origin/master | $check_patch --no-tree --no-signoff -
     echo "OK!"


### PR DESCRIPTION
GitHub API adds some http header lines that are picked up by checkpatch
and cause it to fail.