### PR TITLE
Clarify need for address with NXT/I2C set_device

### DIFF
--- a/brickpi/brickpi_ports_in.c
+++ b/brickpi/brickpi_ports_in.c
@@ -90,8 +90,11 @@ static const struct lego_port_mode_info brickpi_in_port_mode_info[NUM_BRICKPI_IN
 	[BRICKPI_IN_PORT_MODE_NXT_I2C] = {
 		/**
 		 * [^nxt-i2c-mode]: No sensors are loaded by default. You must
-		 * manually specify the sensor that is connected by using the
-		 * `set_device` attribute.
+		 * manually specify the sensor that is connected and its address
+		 * by using the `set_device` attribute. This is equivalent to
+		 * [manually loading] I2C devices.
+		 * ^
+		 * [manually loading]: /docs/sensors/using-i2c-sensors/#manually-loading-devices
 		 *
 		 * @description: NXT/I2C sensor
 		 * @name_footnote: [^nxt-i2c-mode]

--- a/brickpi/brickpi_ports_in.c
+++ b/brickpi/brickpi_ports_in.c
@@ -92,7 +92,9 @@ static const struct lego_port_mode_info brickpi_in_port_mode_info[NUM_BRICKPI_IN
 		 * [^nxt-i2c-mode]: No sensors are loaded by default. You must
 		 * manually specify the sensor that is connected and its address
 		 * by using the `set_device` attribute. This is equivalent to
-		 * [manually loading] I2C devices.
+		 * [manually loading] I2C devices. The sensor port address will
+		 * be the BrickPi port address with ":i2c" and the decimal I2C
+		 * address appended. 
 		 * ^
 		 * [manually loading]: /docs/sensors/using-i2c-sensors/#manually-loading-devices
 		 *

--- a/brickpi/brickpi_ports_in.c
+++ b/brickpi/brickpi_ports_in.c
@@ -94,9 +94,11 @@ static const struct lego_port_mode_info brickpi_in_port_mode_info[NUM_BRICKPI_IN
 		 * by using the `set_device` attribute. This is equivalent to
 		 * [manually loading] I2C devices. The sensor port address will
 		 * be the BrickPi port address with ":i2c" and the decimal I2C
-		 * address appended. 
+		 * address appended. The [BrickPi I2C sensor page] has information
+		 * regarding the use of sensors connected to a brickpi-in-port.
 		 * ^
 		 * [manually loading]: /docs/sensors/using-i2c-sensors/#manually-loading-devices
+		 * [BrickPi I2C sensor]: /docs/drivers/brickpi-i2c-sensor/
 		 *
 		 * @description: NXT/I2C sensor
 		 * @name_footnote: [^nxt-i2c-mode]


### PR DESCRIPTION
This clarifies the need to send the address to `set_device`.

@dlech Please take a look.

(Squash, rebase onto master and add reference to 640 and 642 in commit message prior to merge).