### PR TITLE
ev3 uart: use receive_buf2

### DIFF
--- a/sensors/ev3_uart_sensor_ld.c
+++ b/sensors/ev3_uart_sensor_ld.c
@@ -1034,8 +1034,12 @@ static void ev3_uart_receive_buf(struct tty_struct *tty,
 	if (port->closing)
 		return;
 
-	if (count > CIRC_SPACE(cb->head, cb->tail, EV3_UART_BUFFER_SIZE))
+	if (count > CIRC_SPACE(cb->head, cb->tail, EV3_UART_BUFFER_SIZE)) {
+		printk_ratelimited(KERN_ERR
+				   "%s: buffer overrun\n", dev_name(tty->dev));
+		schedule_work(&port->rx_data_work);
 		return;
+	}
 
 	size = CIRC_SPACE_TO_END(cb->head, cb->tail, EV3_UART_BUFFER_SIZE);
 	if (count > size) {


### PR DESCRIPTION
This callback is preferred over receive_buf since it returns the count
of the bytes that were actually received.

Issue: ev3dev/ev3dev#671