### PR TITLE
ev3 uart: Fix sensors with only 1 mode not detected

### DIFF
--- a/sensors/ev3_uart_sensor_ld.c
+++ b/sensors/ev3_uart_sensor_ld.c
@@ -647,7 +647,7 @@ static void ev3_uart_handle_rx_data(struct work_struct *work)
 					port->last_err = "Received duplicate modes INFO.";
 					goto err_invalid_state;
 				}
-				if (!cmd2 || cmd2 > EV3_UART_MODE_MAX) {
+				if (cmd2 > EV3_UART_MODE_MAX) {
 					port->last_err = "Number of modes is out of range.";
 					goto err_invalid_state;
 				}


### PR DESCRIPTION
0 is a valid value for cmd2. It means that there is one mode.

Issue: ev3dev/ev3dev#663