### PR TITLE
BrickPi workaround to make ms-absolute-imu work before i2c adapter driver

### DIFF
--- a/brickpi/brickpi_i2c_sensor.c
+++ b/brickpi/brickpi_i2c_sensor.c
@@ -137,7 +137,7 @@ static int brickpi_i2c_sensor_probe(struct lego_device *ldev)
 
 	sensor_info = &nxt_i2c_sensor_defs[ldev->entry_id->driver_data];
 
-	/* below temporary workaround for ms_absolute_imu (1 o 4) */
+	/* below temporary workaround for ms_absolute_imu (1 of 4) */
 	if (sensor_info->ops &&
 		ldev->entry_id->driver_data != MS_ABSOLUTE_IMU) {
 		dev_err(&ldev->dev, "The '%s' driver requires special operations"

--- a/brickpi/brickpi_i2c_sensor.c
+++ b/brickpi/brickpi_i2c_sensor.c
@@ -95,27 +95,26 @@ static int brickpi_i2c_sensor_send_command(void *context, u8 mode)
 	const struct nxt_i2c_sensor_cmd_info *i2c_cmd_info = data->info->i2c_cmd_info;
 	const struct nxt_i2c_sensor_mode_info *i2c_mode_info = data->info->i2c_mode_info;
 	int size = lego_sensor_get_raw_data_size(mode_info);
-	
-	int err; //temporary workaround for ms-absolute-imu (2 of 5)
-	struct nxt_i2c_sensor_data workaround_sensor; //workaround (3 of 5)
+
+	int err; /* temporary workaround for ms-absolute-imu (2 of 5) */
+	struct nxt_i2c_sensor_data workaround_sensor; /*workaround (3 of 5) */
 
 	/* set mode function also works for sending command */
 	err = brickpi_in_port_set_i2c_mode(data->ldev,
 					    i2c_cmd_info[mode].cmd_reg,
 					    i2c_cmd_info[mode].cmd_data,
 					    i2c_mode_info[mode].read_data_reg,
-					    size);				
+					    size);		
 
-	//temporary workaround for ms-absolute-imu (4 of 5)
+	/* temporary workaround for ms-absolute-imu (4 of 5) */
 	if (err)
 		return err;
 
-	//temporary workaround for ms-absolute-imu (5 of 5)					
-	if (data->info->ops && data->info->ops->send_cmd_post_cb)
-	{
+	/* temporary workaround for ms-absolute-imu (5 of 5) */
+	if (data->info->ops && data->info->ops->send_cmd_post_cb) {
 		workaround_sensor.sensor.mode_info = data->sensor.mode_info;
-		data->info->ops->send_cmd_post_cb(&workaround_sensor, mode);						
-	}			
+		data->info->ops->send_cmd_post_cb(&workaround_sensor, mode);
+	}
 
 	return err;
 }
@@ -137,8 +136,9 @@ static int brickpi_i2c_sensor_probe(struct lego_device *ldev)
 
 	sensor_info = &nxt_i2c_sensor_defs[ldev->entry_id->driver_data];
 
-	if (sensor_info->ops //below temporary workaround for ms_absolute_imu (1 o 5)
-	&& ldev->entry_id->driver_data != MS_ABSOLUTE_IMU) {
+	/* below temporary workaround for ms_absolute_imu (1 o 5) */
+	if (sensor_info->ops &&
+		ldev->entry_id->driver_data != MS_ABSOLUTE_IMU) {
 		dev_err(&ldev->dev, "The '%s' driver requires special operations"
 			" that are not supported in the '%s' module.",
 			ldev->entry_id->name, "brickpi-i2c-sensor");

--- a/brickpi/brickpi_i2c_sensor.c
+++ b/brickpi/brickpi_i2c_sensor.c
@@ -98,26 +98,25 @@ static int brickpi_i2c_sensor_send_command(void *context, u8 mode)
 	
 	int err; //temporary workaround for ms-absolute-imu (2 of 5)
 	struct nxt_i2c_sensor_data workaround_sensor; //workaround (3 of 5)
-	
+
 	/* set mode function also works for sending command */
 	err = brickpi_in_port_set_i2c_mode(data->ldev,
 					    i2c_cmd_info[mode].cmd_reg,
 					    i2c_cmd_info[mode].cmd_data,
 					    i2c_mode_info[mode].read_data_reg,
-					    size);
-					
-	
+					    size);				
+
 	//temporary workaround for ms-absolute-imu (4 of 5)
 	if (err)
 		return err;
-					
+
 	//temporary workaround for ms-absolute-imu (5 of 5)					
 	if (data->info->ops && data->info->ops->send_cmd_post_cb)
 	{
 		workaround_sensor.sensor.mode_info = data->sensor.mode_info;
 		data->info->ops->send_cmd_post_cb(&workaround_sensor, mode);						
 	}			
-	
+
 	return err;
 }
 

--- a/brickpi/brickpi_i2c_sensor.c
+++ b/brickpi/brickpi_i2c_sensor.c
@@ -115,7 +115,7 @@ static int brickpi_i2c_sensor_send_command(void *context, u8 mode)
 	if (data->info->ops && data->info->ops->send_cmd_post_cb)
 	{
 		workaround_sensor.sensor.mode_info = data->sensor.mode_info;
-		data->info->ops->send_cmd_post_cb(workaround_sensor, mode);						
+		data->info->ops->send_cmd_post_cb(&workaround_sensor, mode);						
 	}			
 	
 	return err;

--- a/brickpi/brickpi_i2c_sensor.c
+++ b/brickpi/brickpi_i2c_sensor.c
@@ -137,7 +137,8 @@ static int brickpi_i2c_sensor_probe(struct lego_device *ldev)
 	sensor_info = &nxt_i2c_sensor_defs[ldev->entry_id->driver_data];
 
 	/* below temporary workaround for ms_absolute_imu (1 o 5) */
-	if (sensor_info->ops && ldev->entry_id->driver_data != MS_ABSOLUTE_IMU) {
+	if (sensor_info->ops &&
+		ldev->entry_id->driver_data != MS_ABSOLUTE_IMU) {
 		dev_err(&ldev->dev, "The '%s' driver requires special operations"
 			" that are not supported in the '%s' module.",
 			ldev->entry_id->name, "brickpi-i2c-sensor");

--- a/brickpi/brickpi_i2c_sensor.c
+++ b/brickpi/brickpi_i2c_sensor.c
@@ -112,6 +112,7 @@ static int brickpi_i2c_sensor_send_command(void *context, u8 mode)
 	if (data->ldev->entry_id->driver_data == MS_ABSOLUTE_IMU &&
 	data->info->ops && data->info->ops->send_cmd_post_cb) {
 		struct nxt_i2c_sensor_data workaround_sensor;
+
 		workaround_sensor.sensor.mode_info = data->sensor.mode_info;
 		data->info->ops->send_cmd_post_cb(&workaround_sensor, mode);
 	}

--- a/brickpi/brickpi_i2c_sensor.c
+++ b/brickpi/brickpi_i2c_sensor.c
@@ -95,13 +95,30 @@ static int brickpi_i2c_sensor_send_command(void *context, u8 mode)
 	const struct nxt_i2c_sensor_cmd_info *i2c_cmd_info = data->info->i2c_cmd_info;
 	const struct nxt_i2c_sensor_mode_info *i2c_mode_info = data->info->i2c_mode_info;
 	int size = lego_sensor_get_raw_data_size(mode_info);
-
+	
+	int err; //temporary workaround for ms-absolute-imu (2 of 5)
+	struct nxt_i2c_sensor_data workaround_sensor; //workaround (3 of 5)
+	
 	/* set mode function also works for sending command */
-	return brickpi_in_port_set_i2c_mode(data->ldev,
+	err = brickpi_in_port_set_i2c_mode(data->ldev,
 					    i2c_cmd_info[mode].cmd_reg,
 					    i2c_cmd_info[mode].cmd_data,
 					    i2c_mode_info[mode].read_data_reg,
 					    size);
+					
+	
+	//temporary workaround for ms-absolute-imu (4 of 5)
+	if (err)
+		return err;
+					
+	//temporary workaround for ms-absolute-imu (5 of 5)					
+	if (data->info->ops && data->info->ops->send_cmd_post_cb)
+	{
+		workaround_sensor.sensor.mode_info = data->sensor.mode_info;
+		data->info->ops->send_cmd_post_cb(workaround_sensor, command);						
+	}			
+	
+	return err;
 }
 
 static int brickpi_i2c_sensor_probe(struct lego_device *ldev)
@@ -121,7 +138,8 @@ static int brickpi_i2c_sensor_probe(struct lego_device *ldev)
 
 	sensor_info = &nxt_i2c_sensor_defs[ldev->entry_id->driver_data];
 
-	if (sensor_info->ops) {
+	if (sensor_info->ops //below temporary workaround for ms_absolute_imu (1 o 5)
+	&& ldev->entry_id->driver_data != MS_ABSOLUTE_IMU) {
 		dev_err(&ldev->dev, "The '%s' driver requires special operations"
 			" that are not supported in the '%s' module.",
 			ldev->entry_id->name, "brickpi-i2c-sensor");

--- a/brickpi/brickpi_i2c_sensor.c
+++ b/brickpi/brickpi_i2c_sensor.c
@@ -95,9 +95,7 @@ static int brickpi_i2c_sensor_send_command(void *context, u8 mode)
 	const struct nxt_i2c_sensor_cmd_info *i2c_cmd_info = data->info->i2c_cmd_info;
 	const struct nxt_i2c_sensor_mode_info *i2c_mode_info = data->info->i2c_mode_info;
 	int size = lego_sensor_get_raw_data_size(mode_info);
-
-	int err; /* temporary workaround for ms-absolute-imu (2 of 5) */
-	struct nxt_i2c_sensor_data workaround_sensor; /*workaround (3 of 5) */
+	int err; /* temporary workaround for ms-absolute-imu (2 of 4) */
 
 	/* set mode function also works for sending command */
 	err = brickpi_in_port_set_i2c_mode(data->ldev,
@@ -106,12 +104,14 @@ static int brickpi_i2c_sensor_send_command(void *context, u8 mode)
 					    i2c_mode_info[mode].read_data_reg,
 					    size);
 
-	/* temporary workaround for ms-absolute-imu (4 of 5) */
+	/* temporary workaround for ms-absolute-imu (3 of 4) */
 	if (err)
 		return err;
 
-	/* temporary workaround for ms-absolute-imu (5 of 5) */
-	if (data->info->ops && data->info->ops->send_cmd_post_cb) {
+	/* temporary workaround for ms-absolute-imu (4 of 4) */
+	if (data->ldev->entry_id->driver_data == MS_ABSOLUTE_IMU &&
+	data->info->ops && data->info->ops->send_cmd_post_cb) {
+		struct nxt_i2c_sensor_data workaround_sensor;
 		workaround_sensor.sensor.mode_info = data->sensor.mode_info;
 		data->info->ops->send_cmd_post_cb(&workaround_sensor, mode);
 	}
@@ -136,7 +136,7 @@ static int brickpi_i2c_sensor_probe(struct lego_device *ldev)
 
 	sensor_info = &nxt_i2c_sensor_defs[ldev->entry_id->driver_data];
 
-	/* below temporary workaround for ms_absolute_imu (1 o 5) */
+	/* below temporary workaround for ms_absolute_imu (1 o 4) */
 	if (sensor_info->ops &&
 		ldev->entry_id->driver_data != MS_ABSOLUTE_IMU) {
 		dev_err(&ldev->dev, "The '%s' driver requires special operations"

--- a/brickpi/brickpi_i2c_sensor.c
+++ b/brickpi/brickpi_i2c_sensor.c
@@ -95,13 +95,25 @@ static int brickpi_i2c_sensor_send_command(void *context, u8 mode)
 	const struct nxt_i2c_sensor_cmd_info *i2c_cmd_info = data->info->i2c_cmd_info;
 	const struct nxt_i2c_sensor_mode_info *i2c_mode_info = data->info->i2c_mode_info;
 	int size = lego_sensor_get_raw_data_size(mode_info);
-
+	int err; //temporary workaround for mi-xg1300l and ms-absolute-imu (5 of 5)
+	
 	/* set mode function also works for sending command */
-	return brickpi_in_port_set_i2c_mode(data->ldev,
+	err = brickpi_in_port_set_i2c_mode(data->ldev,
 					    i2c_cmd_info[mode].cmd_reg,
 					    i2c_cmd_info[mode].cmd_data,
 					    i2c_mode_info[mode].read_data_reg,
 					    size);
+					
+	
+	//temporary workaround for mi-xg1300l and ms-absolute-imu (5 of 5)
+	if (err)
+		return err;
+					
+	//temporary workaround for mi-xg1300l and ms-absolute-imu (5 of 5)					
+	if (sensor->info->ops && sensor->info->ops->send_cmd_post_cb)
+		sensor->info->ops->send_cmd_post_cb(sensor, command);						
+						
+	return err;
 }
 
 static int brickpi_i2c_sensor_probe(struct lego_device *ldev)
@@ -121,7 +133,9 @@ static int brickpi_i2c_sensor_probe(struct lego_device *ldev)
 
 	sensor_info = &nxt_i2c_sensor_defs[ldev->entry_id->driver_data];
 
-	if (sensor_info->ops) {
+	if (sensor_info->ops //temporary workaround for mi-xg1300l and ms-absolute-imu (1 of 5)
+		&& ldev->entry_id->driver_data != MI_CRUIZCORE_XG1300L 
+		&& ldev->entry_id->driver_data != MS_ABSOLUTE_IMU ) {
 		dev_err(&ldev->dev, "The '%s' driver requires special operations"
 			" that are not supported in the '%s' module.",
 			ldev->entry_id->name, "brickpi-i2c-sensor");
@@ -171,6 +185,13 @@ static int brickpi_i2c_sensor_probe(struct lego_device *ldev)
 
 	dev_set_drvdata(&ldev->dev, data);
 
+	//temporary workaround for mi-xg1300l and ms-absolute-imu (2 of 5)
+	if (data->info->ops && data->info->ops->probe_cb) {
+		err = data->info->ops->probe_cb(data);
+		if (err < 0)
+			goto err_probe_cb;
+	}
+	
 	err = register_lego_sensor(&data->sensor, &ldev->dev);
 	if (err) {
 		dev_err(&ldev->dev, "could not register sensor!\n");
@@ -182,7 +203,9 @@ static int brickpi_i2c_sensor_probe(struct lego_device *ldev)
 
 	return 0;
 
-err_register_lego_sensor:
+err_probe_cb:
+err_register_lego_sensor: //consider keeping the line below even without workaround
+	dev_set_drvdata(&ldev->dev, NULL); //workaround for mi-xg1300l and ms-absolute-imu (3 of 5)
 	kfree(data->sensor.mode_info);
 err_kalloc_mode_info:
 	kfree(data);
@@ -194,6 +217,10 @@ static int brickpi_i2c_sensor_remove(struct lego_device *ldev)
 {
 	struct brickpi_i2c_sensor_data *data = dev_get_drvdata(&ldev->dev);
 
+	//temporary workaround for mi-xg1300l and ms-absolute-imu (4 of 5)
+	if (data->info->ops && data->info->ops->remove_cb)
+		data->info->ops->remove_cb(data);	
+	
 	lego_port_set_raw_data_ptr_and_func(ldev->port, NULL, 0, NULL, NULL);
 	unregister_lego_sensor(&data->sensor);
 	dev_set_drvdata(&ldev->dev, NULL);

--- a/brickpi/brickpi_i2c_sensor.c
+++ b/brickpi/brickpi_i2c_sensor.c
@@ -137,8 +137,7 @@ static int brickpi_i2c_sensor_probe(struct lego_device *ldev)
 	sensor_info = &nxt_i2c_sensor_defs[ldev->entry_id->driver_data];
 
 	/* below temporary workaround for ms_absolute_imu (1 o 5) */
-	if (sensor_info->ops &&
-		ldev->entry_id->driver_data != MS_ABSOLUTE_IMU) {
+	if (sensor_info->ops && ldev->entry_id->driver_data != MS_ABSOLUTE_IMU) {
 		dev_err(&ldev->dev, "The '%s' driver requires special operations"
 			" that are not supported in the '%s' module.",
 			ldev->entry_id->name, "brickpi-i2c-sensor");

--- a/brickpi/brickpi_i2c_sensor.c
+++ b/brickpi/brickpi_i2c_sensor.c
@@ -115,7 +115,7 @@ static int brickpi_i2c_sensor_send_command(void *context, u8 mode)
 	if (data->info->ops && data->info->ops->send_cmd_post_cb)
 	{
 		workaround_sensor.sensor.mode_info = data->sensor.mode_info;
-		data->info->ops->send_cmd_post_cb(workaround_sensor, command);						
+		data->info->ops->send_cmd_post_cb(workaround_sensor, mode);						
 	}			
 	
 	return err;

--- a/brickpi/brickpi_i2c_sensor.c
+++ b/brickpi/brickpi_i2c_sensor.c
@@ -104,7 +104,7 @@ static int brickpi_i2c_sensor_send_command(void *context, u8 mode)
 					    i2c_cmd_info[mode].cmd_reg,
 					    i2c_cmd_info[mode].cmd_data,
 					    i2c_mode_info[mode].read_data_reg,
-					    size);		
+					    size);
 
 	/* temporary workaround for ms-absolute-imu (4 of 5) */
 	if (err)


### PR DESCRIPTION
This is ugly hack and only for ms_absolute_imu. For mi-xg1300l it's far worse than that.

I don't really expect that @dlech merges it but this is the minimum code to make it work.

It relies on two facts:
- ms_imu uses only send_cmd_post_cb from ops
- in this function it only uses nxt_i2c_sensor_data.lego_sensor_device.mode_info

So the workaround creates mockup nxt_i2c_sensor_data with only this field filled. 

The bad thing is that everytime send_cmd is called a rather big mockup nxt_i2c_sensor_data structure is declared.

I have no means to test it (no ms_absolute_imu).

I am going to start working on i2c adapter driver in the free time (if nobody is working on it).