### PR TITLE
increase EV3_UART_BUFFER_SIZE to 1024 bytes

### DIFF
--- a/sensors/ev3_uart_sensor_ld.c
+++ b/sensors/ev3_uart_sensor_ld.c
@@ -76,7 +76,7 @@
 #endif
 
 /* EV3_UART_BUFFER_SIZE must be power of 2 for circ_buf macros */
-#define EV3_UART_BUFFER_SIZE		256
+#define EV3_UART_BUFFER_SIZE		1024
 #define EV3_UART_MAX_DATA_SIZE		32
 #define EV3_UART_MAX_MESSAGE_SIZE	(EV3_UART_MAX_DATA_SIZE + 2)
 

--- a/sensors/ev3_uart_sensor_ld.c
+++ b/sensors/ev3_uart_sensor_ld.c
@@ -76,7 +76,7 @@
 #endif
 
 /* EV3_UART_BUFFER_SIZE must be power of 2 for circ_buf macros */
-#define EV3_UART_BUFFER_SIZE		128
+#define EV3_UART_BUFFER_SIZE		1024
 #define EV3_UART_MAX_DATA_SIZE		32
 #define EV3_UART_MAX_MESSAGE_SIZE	(EV3_UART_MAX_DATA_SIZE + 2)
 

--- a/sensors/ev3_uart_sensor_ld.c
+++ b/sensors/ev3_uart_sensor_ld.c
@@ -76,7 +76,7 @@
 #endif
 
 /* EV3_UART_BUFFER_SIZE must be power of 2 for circ_buf macros */
-#define EV3_UART_BUFFER_SIZE		1024
+#define EV3_UART_BUFFER_SIZE		128
 #define EV3_UART_MAX_DATA_SIZE		32
 #define EV3_UART_MAX_MESSAGE_SIZE	(EV3_UART_MAX_DATA_SIZE + 2)
 


### PR DESCRIPTION
At current 256 bytes buffer there are occasional overruns leading to UART sensor reconnections.

This is especially evident when changing buffer size to 128 bytes where under high load overruns are notorious.

1024 bytes buffer was tested in high load  scenario for 1 hour without overruns.

Note:

Also when reconnection happens surrounded with multiple overruns there seems to be some extremely rare edge case (race?) when sensor changes mode after reconnection.  This pull will likely hide this edge case problem. It will just not be hit anymore (no reconnections). It's hard to reproduce even with plenty of overruns. This is another thing to consider.