### PR TITLE
Changed the in #1210 described line to fic ENOMEM error with HT Sensor Multiplexer

### DIFF
--- a/sensors/ht_nxt_smux.c
+++ b/sensors/ht_nxt_smux.c
@@ -283,15 +283,19 @@ static void ht_nxt_smux_port_detect_sensor(struct ht_nxt_smux_port_data *data)
 
 	if (data->port.mode == HT_NXT_SMUX_PORT_MODE_ANALOG) {
 		ret = ht_nxt_smux_register_analog_sensor(data, GENERIC_NXT_ANALOG_SENSOR_NAME);
-		if (ret < 0)
+		if (ret < 0) {
 			dev_err(&data->port.dev,
 				"Failed to register analog sensor (%d)\n", ret);
+			return;
+		}
 	} else {
 		ret = i2c_smbus_read_byte_data(data->i2c->client,
 			config_reg + HT_NXT_SMUX_CFG_TYPE);
-		if (ret < 0)
+		if (ret < 0) {
 			dev_err(&data->port.dev,
 				"Failed to read I2C sensor type (%d)\n", ret);
+			return;
+		}
 		if (ret < NUM_HT_NXT_SMUX_SENSOR_TYPE)
 			name = ht_nxt_smux_supported_i2c_sensor_names[ret];
 		if (name) {
@@ -303,10 +307,12 @@ static void ht_nxt_smux_port_detect_sensor(struct ht_nxt_smux_port_data *data)
 				return;
 			}
 			ret = ht_nxt_smux_register_i2c_sensor(data, name, ret);
-			if (ret < 0)
+			if (ret < 0) {
 				dev_err(&data->port.dev,
 					"Failed to register I2C sensor (%d)\n",
 					ret);
+				return;
+			}
 		}
 	}
 }

--- a/sensors/ht_nxt_smux.c
+++ b/sensors/ht_nxt_smux.c
@@ -153,8 +153,8 @@ static inline bool ht_nxt_smux_is_running(struct nxt_i2c_sensor_data *data)
 		& HT_NXT_SMUX_STATUS_BUSY;
 }
 
-int ht_nxt_smux_port_set_config_bit(struct ht_nxt_smux_port_data * data, u8 bit,
-				    bool value)
+static int ht_nxt_smux_port_set_config_bit(struct ht_nxt_smux_port_data *data,
+					   u8 bit, bool value)
 {
 	int offset = ht_nxt_smux_config_reg[data->channel];
 	int old, new;
@@ -232,8 +232,8 @@ void ht_nxt_smux_port_set_i2c_data_reg(struct lego_port_device *port, u8 reg,
 }
 EXPORT_SYMBOL_GPL(ht_nxt_smux_port_set_i2c_data_reg);
 
-int ht_nxt_smux_register_analog_sensor(struct ht_nxt_smux_port_data *data,
-					 const char *name)
+static int ht_nxt_smux_register_analog_sensor(struct ht_nxt_smux_port_data *data,
+					      const char *name)
 {
 	struct lego_device *new_sensor;
 
@@ -247,8 +247,8 @@ int ht_nxt_smux_register_analog_sensor(struct ht_nxt_smux_port_data *data,
 	return 0;
 }
 
-int ht_nxt_smux_register_i2c_sensor(struct ht_nxt_smux_port_data *data,
-				    const char *name, u8 address)
+static int ht_nxt_smux_register_i2c_sensor(struct ht_nxt_smux_port_data *data,
+					   const char *name, u8 address)
 {
 	struct ht_nxt_smux_i2c_sensor_platform_data pdata;
 	struct lego_device *new_sensor;
@@ -265,7 +265,7 @@ int ht_nxt_smux_register_i2c_sensor(struct ht_nxt_smux_port_data *data,
 	return 0;
 }
 
-void ht_nxt_smux_unregister_sensor(struct ht_nxt_smux_port_data *data)
+static void ht_nxt_smux_unregister_sensor(struct ht_nxt_smux_port_data *data)
 {
 	if (data->sensor) {
 		lego_device_unregister(data->sensor);
@@ -273,7 +273,7 @@ void ht_nxt_smux_unregister_sensor(struct ht_nxt_smux_port_data *data)
 	}
 }
 
-void ht_nxt_smux_port_detect_sensor(struct ht_nxt_smux_port_data *data)
+static void ht_nxt_smux_port_detect_sensor(struct ht_nxt_smux_port_data *data)
 {
 	int config_reg = ht_nxt_smux_config_reg[data->channel];
 	int ret;

--- a/sensors/ht_nxt_smux_i2c_sensor.c
+++ b/sensors/ht_nxt_smux_i2c_sensor.c
@@ -91,6 +91,7 @@ static int ht_nxt_smux_i2c_sensor_probe(struct lego_device *ldev)
 		return -ENOMEM;
 
 	mode_info_size = sizeof(struct nxt_i2c_sensor_info) * sensor_info->num_modes;
+	data->sensor.mode_info = kmalloc(mode_info_size, GFP_KERNEL);
 	if (!data->sensor.mode_info) {
 		err = -ENOMEM;
 		goto err_kalloc_mode_info;


### PR DESCRIPTION
I did like in https://github.com/ev3dev/ev3dev/issues/1210 described, and the `HT SMUX` is now detecting the Sensors. But the values are always `255`, they are not changing,