### PR TITLE
fix: change UART message buffer size to 35 bytes

### DIFF
--- a/sensors/ev3_uart_sensor_ld.c
+++ b/sensors/ev3_uart_sensor_ld.c
@@ -66,7 +66,8 @@
 #endif
 
 #define EV3_UART_MAX_DATA_SIZE		32
-#define EV3_UART_MAX_MESSAGE_SIZE	(EV3_UART_MAX_DATA_SIZE + 2)
+/* extra bytes for: main command byte, INFO command byte, final checksum */
+#define EV3_UART_MAX_MESSAGE_SIZE	(EV3_UART_MAX_DATA_SIZE + 3)
 
 #define EV3_UART_MSG_TYPE_MASK		0xC0
 #define EV3_UART_CMD_SIZE(byte)		(1 << (((byte) >> 3) & 0x7))


### PR DESCRIPTION
Previously, the buffer was only 34 bytes large. This would overflow the buffer if an INFO message with 32 byte payload was received. The problem is the INFO command byte that is not counted to the payload size.

I haven't tested the change yet, but I will try to do so.