### PR TITLE
Add data "age" attribute to sensor sysfs

### DIFF
--- a/brickpi/brickpi_i2c_sensor.c
+++ b/brickpi/brickpi_i2c_sensor.c
@@ -76,6 +76,7 @@ static int brickpi_i2c_sensor_set_mode(void *context, u8 mode)
 		return err;
 
 	lego_port_set_raw_data_ptr_and_func(port, mode_info->raw_data, size,
+					    &mode_info->last_changed_time,
 					    NULL, NULL);
 
 	return 0;
@@ -205,7 +206,8 @@ static int brickpi_i2c_sensor_remove(struct lego_device *ldev)
 {
 	struct brickpi_i2c_sensor_data *data = dev_get_drvdata(&ldev->dev);
 
-	lego_port_set_raw_data_ptr_and_func(ldev->port, NULL, 0, NULL, NULL);
+	lego_port_set_raw_data_ptr_and_func(ldev->port, NULL, 0, NULL,
+					    NULL, NULL);
 	unregister_lego_sensor(&data->sensor);
 	dev_set_drvdata(&ldev->dev, NULL);
 	kfree(data->sensor.mode_info);

--- a/ev3/ev3_ports_in.c
+++ b/ev3/ev3_ports_in.c
@@ -526,16 +526,30 @@ static struct lego_port_nxt_analog_ops ev3_input_port_nxt_analog_ops = {
 
 static void ev3_input_port_nxt_analog_cb(struct ev3_input_port_data *data)
 {
-	if (data->port.raw_data)
-		*(s32 *)data->port.raw_data = data->pin1_mv;
+	s32 new_value = data->pin1_mv;
+	s32 *raw_data = (s32 *)data->port.raw_data;
+
+	if (raw_data) {
+		if (*raw_data != new_value && data->port.last_changed_time)
+			*data->port.last_changed_time = ktime_get();
+
+		*raw_data = new_value;
+	}
 	if (data->port.notify_raw_data_func)
 		data->port.notify_raw_data_func(data->port.notify_raw_data_context);
 }
 
 static void ev3_input_port_ev3_analog_cb(struct ev3_input_port_data *data)
 {
-	if (data->port.raw_data)
-		*(s32 *)data->port.raw_data = data->pin6_mv;
+	s32 new_value = data->pin6_mv;
+	s32 *raw_data = (s32 *)data->port.raw_data;
+
+	if (raw_data) {
+		if (*raw_data != new_value && data->port.last_changed_time)
+			*data->port.last_changed_time = ktime_get();
+
+		*raw_data = new_value;
+	}
 	if (data->port.notify_raw_data_func)
 		data->port.notify_raw_data_func(data->port.notify_raw_data_context);
 }

--- a/include/lego_port_class.h
+++ b/include/lego_port_class.h
@@ -84,6 +84,7 @@ struct lego_port_ev3_uart_ops {
  * @dev: The device data structure.
  * @raw_data: Pointer to raw data storage.
  * @raw_data_size: Size of raw_data in bytes.
+ * @last_changed_time: Time at which the raw_data last changed its contents.
  * @notify_raw_data_func: Registered by sensor drivers to be notified of new
  * 	raw data.
  * @notify_raw_data_context: Send to notify_raw_data_func as parameter.
@@ -112,6 +113,7 @@ struct lego_port_device {
 	struct device dev;
 	u8 *raw_data;
 	unsigned raw_data_size;
+	ktime_t *last_changed_time;
 	lego_port_notify_raw_data_func_t notify_raw_data_func;
 	void *notify_raw_data_context;
 };
@@ -126,11 +128,13 @@ extern void lego_port_unregister(struct lego_port_device *lego_port);
 static inline void
 lego_port_set_raw_data_ptr_and_func(struct lego_port_device *port,
 				    u8 *raw_data, unsigned raw_data_size,
+				    ktime_t *last_changed_time,
 				    lego_port_notify_raw_data_func_t func,
 				    void *context)
 {
 	port->raw_data = raw_data;
 	port->raw_data_size = raw_data_size;
+	port->last_changed_time = last_changed_time;
 	port->notify_raw_data_func = func;
 	port->notify_raw_data_context = context;
 }

--- a/include/lego_sensor_class.h
+++ b/include/lego_sensor_class.h
@@ -19,6 +19,7 @@
 
 #include <linux/device.h>
 #include <linux/types.h>
+#include <linux/ktime.h>
 
 #define LEGO_SENSOR_NAME_SIZE		30
 #define LEGO_SENSOR_FW_VERSION_SIZE	8
@@ -62,6 +63,7 @@ extern size_t lego_sensor_data_size[];
  * @figures: Number of digits that should be displayed, including decimal point.
  * @decimals: Decimal point position.
  * @raw_data: Raw data read from the sensor.
+ * @last_changed_time: Time at which the raw_data last changed its contents.
  */
 struct lego_sensor_mode_info {
 	char name[LEGO_SENSOR_MODE_NAME_SIZE + 1];
@@ -80,6 +82,7 @@ struct lego_sensor_mode_info {
 	u8 figures;
 	u8 decimals;
 	u8 raw_data[LEGO_SENSOR_RAW_DATA_SIZE];
+	ktime_t last_changed_time;
 };
 
 /**

--- a/sensors/ev3_analog_sensor_core.c
+++ b/sensors/ev3_analog_sensor_core.c
@@ -61,7 +61,8 @@ static int ev3_analog_sensor_set_mode(void *context, u8 mode)
 	else
 		context = NULL;
 	lego_port_set_raw_data_ptr_and_func(data->ldev->port, mode_info->raw_data,
-		lego_sensor_get_raw_data_size(mode_info), func, context);
+		lego_sensor_get_raw_data_size(mode_info),
+		&mode_info->last_changed_time, func, context);
 
 	return 0;
 }
@@ -108,7 +109,8 @@ static int ev3_analog_sensor_remove(struct lego_device *ldev)
 {
 	struct ev3_analog_sensor_data *data = dev_get_drvdata(&ldev->dev);
 
-	lego_port_set_raw_data_ptr_and_func(ldev->port, NULL, 0, NULL, NULL);
+	lego_port_set_raw_data_ptr_and_func(ldev->port, NULL, 0, NULL,
+					    NULL, NULL);
 	unregister_lego_sensor(&data->sensor);
 	dev_set_drvdata(&ldev->dev, NULL);
 	kfree(data);

--- a/sensors/ev3_uart_sensor_core.c
+++ b/sensors/ev3_uart_sensor_core.c
@@ -59,7 +59,8 @@ static int ev3_uart_sensor_set_mode(void *context, u8 mode)
 		return -EOPNOTSUPP;
 
 	lego_port_set_raw_data_ptr_and_func(data->ldev->port, mode_info->raw_data,
-		lego_sensor_get_raw_data_size(mode_info), NULL, NULL);
+		lego_sensor_get_raw_data_size(mode_info),
+		&mode_info->last_changed_time, NULL, NULL);
 
 	return 0;
 }
@@ -112,7 +113,8 @@ static int ev3_uart_sensor_remove(struct lego_device *ldev)
 {
 	struct ev3_uart_sensor_data *data = dev_get_drvdata(&ldev->dev);
 
-	lego_port_set_raw_data_ptr_and_func(ldev->port, NULL, 0, NULL, NULL);
+	lego_port_set_raw_data_ptr_and_func(ldev->port, NULL, 0, NULL,
+					    NULL, NULL);
 	unregister_lego_sensor(&data->sensor);
 	dev_set_drvdata(&ldev->dev, NULL);
 	kfree(data);

--- a/sensors/ev3_uart_sensor_ld.c
+++ b/sensors/ev3_uart_sensor_ld.c
@@ -953,7 +953,16 @@ static int ev3_uart_receive_buf2(struct tty_struct *tty,
 			if (!completion_done(&port->set_mode_completion)
 			    && mode == port->new_mode)
 				complete(&port->set_mode_completion);
-			memcpy(port->mode_info[mode].raw_data, message + 1, msg_size - 2);
+
+			if (memcmp(port->mode_info[mode].raw_data, message + 1,
+				   msg_size - 2) != 0) {
+				port->mode_info[mode].last_changed_time =
+					ktime_get();
+				memcpy(port->mode_info[mode].raw_data,
+				       message + 1,
+				       msg_size - 2);
+			}
+
 			port->data_rec = 1;
 			if (port->num_data_err)
 				port->num_data_err--;

--- a/sensors/ht_nxt_smux_i2c_sensor.c
+++ b/sensors/ht_nxt_smux_i2c_sensor.c
@@ -57,6 +57,7 @@ static int ht_nxt_smux_i2c_sensor_set_mode(void *context, u8 mode)
 	ht_nxt_smux_port_set_i2c_data_reg(port, i2c_mode_info[mode].read_data_reg,
 					  size);
 	lego_port_set_raw_data_ptr_and_func(port, mode_info->raw_data, size,
+					    &mode_info->last_changed_time,
 					    NULL, NULL);
 
 	return 0;
@@ -155,7 +156,8 @@ static int ht_nxt_smux_i2c_sensor_remove(struct lego_device *ldev)
 {
 	struct ht_nxt_smux_i2c_sensor_data *data = dev_get_drvdata(&ldev->dev);
 
-	lego_port_set_raw_data_ptr_and_func(ldev->port, NULL, 0, NULL, NULL);
+	lego_port_set_raw_data_ptr_and_func(ldev->port, NULL, 0, NULL,
+					    NULL, NULL);
 	ldev->port->nxt_i2c_ops->set_pin1_gpio(ldev->port->context,
 					       LEGO_PORT_GPIO_FLOAT);
 	unregister_lego_sensor(&data->sensor);

--- a/sensors/nxt_analog_sensor_core.c
+++ b/sensors/nxt_analog_sensor_core.c
@@ -63,7 +63,8 @@ static int nxt_analog_sensor_set_mode(void *context, u8 mode)
 	else
 		context = NULL;
 	lego_port_set_raw_data_ptr_and_func(data->ldev->port, mode_info->raw_data,
-		lego_sensor_get_raw_data_size(mode_info), func, context);
+		lego_sensor_get_raw_data_size(mode_info),
+		&mode_info->last_changed_time, func, context);
 	data->ldev->port->nxt_analog_ops->set_pin5_gpio(data->ldev->port->context,
 		data->info.analog_mode_info[mode].pin5_state);
 
@@ -116,7 +117,8 @@ static int nxt_analog_sensor_remove(struct lego_device *ldev)
 
 	ldev->port->nxt_analog_ops->set_pin5_gpio(ldev->port->context,
 		LEGO_PORT_GPIO_FLOAT);
-	lego_port_set_raw_data_ptr_and_func(ldev->port, NULL, 0, NULL, NULL);
+	lego_port_set_raw_data_ptr_and_func(ldev->port, NULL, 0, NULL,
+					    NULL, NULL);
 	unregister_lego_sensor(&data->sensor);
 	dev_set_drvdata(&ldev->dev, NULL);
 	kfree(data);

--- a/wedo/wedo_port.c
+++ b/wedo/wedo_port.c
@@ -538,6 +538,7 @@ void wedo_port_update_status(struct wedo_port_data *wpd)
 	struct wedo_sensor_data *wsd = NULL;
 	struct wedo_motor_data *wmd = NULL;
 	struct wedo_servo_data *wvd = NULL;
+	struct lego_sensor_mode_info *mode_info;
 
 	switch (wpd->type_id) {
 
@@ -545,7 +546,11 @@ void wedo_port_update_status(struct wedo_port_data *wpd)
 	case WEDO_TYPE_MOTION:
 		wsd = wpd->sensor_data;
 		if (wsd) {
-			wsd->info.mode_info[wsd->sensor.mode].raw_data[0] = wpd->input;
+			mode_info = &wsd->info.mode_info[wsd->sensor.mode];
+
+			if (mode_info->raw_data[0] != wpd->input)
+				mode_info->last_changed_time = ktime_get();
+			mode_info->raw_data[0] = wpd->input;
 		}
 		break;
 	case WEDO_TYPE_SERVO:


### PR DESCRIPTION
I would like to propose a workaround for https://github.com/ev3dev/ev3dev/issues/1401 . A new sysfs attribute is exported: `bin_data_age`. It contains the number of milliseconds elapsed since the raw data received from given sensor last changed. This enables userspace to detect conditions like ultrasonic sensor not being able to measure distance at the current position. Thanks to `mode_info` separation present in current drivers, this also works across mode switches - if the same stale data are received after switch, the timestamp of last data update is not reset.

I think the naming (`bin_data_age`) is a bit unfortunate, but I don't know a better alternative. "Age" implies that the sensor did not send any new data during this time, but this may not be true. Sensor may still be sending data, but if they are the same as the old values, "age" is not reset to zero. I would like `bin_data_msec_since_last_change` more, but that is likely too long.

This patch also can't report age of individual values. One use I currently see is for detecting freezes on individual EV3 IR seeker channels. This would mean exporting age for each value separately, which may (or may not) be what is best for ev3dev.

The EV3 color sensor needs a different workaround - here the sensor sends new data, but they aren't accurate yet.