### PR TITLE
sensors/ev3_uart_sensor_ld: fix RGB-RAW condition check

### DIFF
--- a/sensors/ev3_uart_sensor_ld.c
+++ b/sensors/ev3_uart_sensor_ld.c
@@ -652,8 +652,8 @@ static int ev3_uart_receive_buf2(struct tty_struct *tty,
 			 * improved if someone can find a pattern.
 			 */
 			if (chksum != message[msg_size - 1]
-			    && port->type_id != EV3_UART_TYPE_ID_COLOR
-			    && message[0] != 0xDC)
+			    && !(port->type_id == EV3_UART_TYPE_ID_COLOR
+				 && message[0] == 0xDC))
 			{
 				port->last_err = "Bad checksum.";
 				if (port->info_done) {


### PR DESCRIPTION
Previously, checksum was ignored for any mode 4. This fixes it so that only color sensor mode 4 is removed from checksum calculation.