### PR TITLE
Adding a footnote in the ht-nxt-compass docs clarifying how to calibrate the compass sensor.

### DIFF
--- a/sensors/nxt_i2c_sensor_defs.c
+++ b/sensors/nxt_i2c_sensor_defs.c
@@ -772,7 +772,7 @@ const struct nxt_i2c_sensor_info nxt_i2c_sensor_defs[] = {
 				 *    =======  =============
 				 *
 				 * @description: Direction (unmodulated)
-				 * @value0: Direction (0 to 9)
+				 * @value0: Direction (0 to 9) These directions do not directly corresponds to the DC-ALL mode's 5 sensor values. the even number directions are calculated in the sensor (may have interference from sunlight)
 				 * @value0_footnote: [#ht-nxt-ir-seek-v2-mode0-value0]_
 				 */
 				.name = "DC",
@@ -782,7 +782,7 @@ const struct nxt_i2c_sensor_info nxt_i2c_sensor_defs[] = {
 			[1] = {
 				/**
 				 * @description: Direction (modulated)
-				 * @value0: Direction (0 to 9)
+				 * @value0: Direction (0 to 9) These directions do not directly corresponds to the AC-ALL mode's 5 sensor values. the even number directions are calculated in the sensor
 				 * @value0_footnote: [#ht-nxt-ir-seek-v2-mode0-value0]_
 				 */
 				.name = "AC",
@@ -794,17 +794,17 @@ const struct nxt_i2c_sensor_info nxt_i2c_sensor_defs[] = {
 				 * @description: All values (unmodulated)
 				 * @value0: Direction (0 to 9)
 				 * @value0_footnote: [#ht-nxt-ir-seek-v2-mode0-value0]_
-				 * @value1: Sensor 1 signal strength (0 to 9)
+				 * @value1: Sensor 1 (far left direction) signal strength (0 to ~130) (upper limit dependent on IR source strength).
 				 * @value1_footnote: [#ht-nxt-ir-seek-v2-mode0-value0]_
-				 * @value2: Sensor 2 signal strength (0 to 9)
+				 * @value2: Sensor 2 (left-forward direction) signal strength (0 to ~130) (upper limit dependent on IR source strength)
 				 * @value2_footnote: [#ht-nxt-ir-seek-v2-mode0-value0]_
-				 * @value3: Sensor 3 signal strength (0 to 9)
+				 * @value3: Sensor 3 (forward direction) signal strength (0 to ~130) (upper limit dependent on IR source strength)
 				 * @value3_footnote: [#ht-nxt-ir-seek-v2-mode0-value0]_
-				 * @value4: Sensor 4 signal strength (0 to 9)
+				 * @value4: Sensor 4 (right-forward direction) signal strength (0 to ~130) (upper limit dependent on IR source strength)
 				 * @value4_footnote: [#ht-nxt-ir-seek-v2-mode0-value0]_
-				 * @value5: Sensor 5 signal strength (0 to 9)
+				 * @value5: Sensor 5 (far right direction) signal strength (0 to ~130) (upper limit dependent on IR source strength)
 				 * @value5_footnote: [#ht-nxt-ir-seek-v2-mode0-value0]_
-				 * @value6: Sensor mean (0 to 9)
+				 * @value6: Sensor mean (0 to ~ 130) (upper limit dependent on IR source strength) (may be affected by sunlight)
 				 * @value6_footnote: [#ht-nxt-ir-seek-v2-mode0-value0]_
 				 */
 				.name = "DC-ALL",

--- a/sensors/nxt_i2c_sensor_defs.c
+++ b/sensors/nxt_i2c_sensor_defs.c
@@ -1229,13 +1229,22 @@ const struct nxt_i2c_sensor_info nxt_i2c_sensor_defs[] = {
 		.cmd_info	= (const struct lego_sensor_cmd_info[]) {
 			[0]= {
 				/**
+				 * 
+				 * 
+				 * .. [#ht-nxt-compass-cmd1] to calibrating a sensor
+				 *    1. Call the BEGIN-CAL command
+				 *    2. Rotate the robot around 540-720 degrees at a speed of 1 full turn per 20 seconds
+				 *    3. Call the END-CAL command
+				 * 
 				 * @description: Begin calibration
+				 * @command1_footnote: [#ht-nxt-compass-cmd1]_
 				 */
 				.name = "BEGIN-CAL",
 			},
 			[1]= {
 				/**
 				 * @description: End calibration
+				 * @command2_footnote: [#ht-nxt-compass-cmd1]_
 				 */
 				.name = "END-CAL",
 			},

--- a/sensors/nxt_i2c_sensor_defs.c
+++ b/sensors/nxt_i2c_sensor_defs.c
@@ -770,7 +770,7 @@ const struct nxt_i2c_sensor_info nxt_i2c_sensor_defs[] = {
 				 *     ...
 				 *     9        Far right
 				 *    =======  =============
-				 *    These directions do not directly corresponds to the DC-ALL mode's 5 sensor values. 
+				 *    These directions do not directly corresponds to the DC-ALL or AC-ALL mode's 5 sensor values. 
 				 *    the even number directions are calculated in the sensor, while the odd number directions
 				 *    are measured actually measured by sensors 1-5 inside the HiTechnic NXT IRSeeker V2
 				 * 
@@ -795,7 +795,7 @@ const struct nxt_i2c_sensor_info nxt_i2c_sensor_defs[] = {
 			},
 			[2] = {
 				/**
-				 * .. [#ht-nxt-ir-seek-v2-mode2-value1] Signal strengths may not reach as high as 255. Strength is dependent on many factors such as IR source strength, sunlight interference etc.
+				 * .. [#ht-nxt-ir-seek-v2-mode2-value1] Signal strengths may not reach as high as 255. Strength is dependent on many factors such as IR source strength etc.
 				 */
 				/**
 				 * @description: All values (unmodulated)
@@ -827,7 +827,7 @@ const struct nxt_i2c_sensor_info nxt_i2c_sensor_defs[] = {
 				/**
 				 * @description: All values (modulated)
 				 * @value0: Direction (0 to 9)
-				 * @value0_footnote: [#ht-nxt-ir-seek-v2-mode2-value1]_
+				 * @value0_footnote: [#ht-nxt-ir-seek-v2-mode0-value0]_
 				 * @value1: Sensor 1 (far left direction) signal strength 
 				 * (0 to 255)
 				 * @value1_footnote: [#ht-nxt-ir-seek-v2-mode2-value1]_

--- a/sensors/nxt_i2c_sensor_defs.c
+++ b/sensors/nxt_i2c_sensor_defs.c
@@ -1232,9 +1232,9 @@ const struct nxt_i2c_sensor_info nxt_i2c_sensor_defs[] = {
 				 * 
 				 * 
 				 * .. [#ht-nxt-compass-cmd1] to calibrate a sensor,
-				 *    Call the BEGIN-CAL command,
-				 *    Rotate the robot around 540-720 degrees at a speed of 1 full turn per 20 seconds,
-				 *    Call the END-CAL command.
+				 *    Call the BEGIN-CAL command, then
+				 *    rotate the robot around 540-720 degrees at a speed of 1 full turn per 20 seconds, then
+				 *    call the END-CAL command. Now your robot is calibrated and ready to go. 
 				 * 
 				 * @description: Begin calibration
 				 * @name_footnote: [#ht-nxt-compass-cmd1]_

--- a/sensors/nxt_i2c_sensor_defs.c
+++ b/sensors/nxt_i2c_sensor_defs.c
@@ -786,7 +786,7 @@ const struct nxt_i2c_sensor_info nxt_i2c_sensor_defs[] = {
 			[1] = {
 				/**
 				 * @description: Direction (modulated)
-				 * @value0: Direction (0 to 9) These directions do not directly corresponds to the AC-ALL mode's 5 sensor values. the even number directions are calculated in the sensor
+				 * @value0: Direction (0 to 9)
 				 * @value0_footnote: [#ht-nxt-ir-seek-v2-mode0-value0]_
 				 */
 				.name = "AC",

--- a/sensors/nxt_i2c_sensor_defs.c
+++ b/sensors/nxt_i2c_sensor_defs.c
@@ -815,15 +815,15 @@ const struct nxt_i2c_sensor_info nxt_i2c_sensor_defs[] = {
 				 * @description: All values (modulated)
 				 * @value0: Direction (0 to 9)
 				 * @value0_footnote: [#ht-nxt-ir-seek-v2-mode0-value0]_
-				 * @value1: Sensor 1 signal strength (0 to 9)
+				 * @value1: Sensor 1 (far left direction) signal strength (0 to ~130) (upper limit dependent on IR source strength).
 				 * @value1_footnote: [#ht-nxt-ir-seek-v2-mode0-value0]_
-				 * @value2: Sensor 2 signal strength (0 to 9)
+				 * @value2: Sensor 2 (left-forward direction) signal strength (0 to ~130) (upper limit dependent on IR source strength)
 				 * @value2_footnote: [#ht-nxt-ir-seek-v2-mode0-value0]_
-				 * @value3: Sensor 3 signal strength (0 to 9)
+				 * @value3: Sensor 3 (forward direction) signal strength (0 to ~130) (upper limit dependent on IR source strength)
 				 * @value3_footnote: [#ht-nxt-ir-seek-v2-mode0-value0]_
-				 * @value4: Sensor 4 signal strength (0 to 9)
+				 * @value4: Sensor 4 (right-forward direction) signal strength (0 to ~130) (upper limit dependent on IR source strength)
 				 * @value4_footnote: [#ht-nxt-ir-seek-v2-mode0-value0]_
-				 * @value5: Sensor 5 signal strength (0 to 9)
+				 * @value5: Sensor 5 (far right direction) signal strength (0 to ~130) (upper limit dependent on IR source strength)
 				 * @value5_footnote: [#ht-nxt-ir-seek-v2-mode0-value0]_
 				 */
 				.name = "AC-ALL",

--- a/sensors/nxt_i2c_sensor_defs.c
+++ b/sensors/nxt_i2c_sensor_defs.c
@@ -770,6 +770,9 @@ const struct nxt_i2c_sensor_info nxt_i2c_sensor_defs[] = {
 				 *     ...
 				 *     9        Far right
 				 *    =======  =============
+				 *    AC mode runs the Sensor in modulated mode, aimed at detecting modulated IR signals such as from HiTechnic IRBall or
+				 *    some types of IR remote controls.
+				 *    DC mode runs the Sensor in unmodulated mode, detecting both modulated and unmodulated IR signals such as sunlight.
 				 *    These directions do not directly corresponds to the DC-ALL or AC-ALL mode's 5 sensor values. 
 				 *    the even number directions are calculated in the sensor, while the odd number directions
 				 *    are measured actually measured by sensors 1-5 inside the HiTechnic NXT IRSeeker V2

--- a/sensors/nxt_i2c_sensor_defs.c
+++ b/sensors/nxt_i2c_sensor_defs.c
@@ -1237,14 +1237,14 @@ const struct nxt_i2c_sensor_info nxt_i2c_sensor_defs[] = {
 				 *    Call the END-CAL command.
 				 * 
 				 * @description: Begin calibration
-				 * @name_footnote: [#ht-nxt-compass-cmd1]_
+				 * @description_footnote: [#ht-nxt-compass-cmd1]_
 				 */
 				.name = "BEGIN-CAL",
 			},
 			[1]= {
 				/**
 				 * @description: End calibration
-				 * @name_footnote: [#ht-nxt-compass-cmd1]_
+				 * @description_footnote: [#ht-nxt-compass-cmd1]_
 				 */
 				.name = "END-CAL",
 			},

--- a/sensors/nxt_i2c_sensor_defs.c
+++ b/sensors/nxt_i2c_sensor_defs.c
@@ -1231,20 +1231,20 @@ const struct nxt_i2c_sensor_info nxt_i2c_sensor_defs[] = {
 				/**
 				 * 
 				 * 
-				 * .. [#ht-nxt-compass-cmd1] to calibrating a sensor
-				 *    1. Call the BEGIN-CAL command
-				 *    2. Rotate the robot around 540-720 degrees at a speed of 1 full turn per 20 seconds
-				 *    3. Call the END-CAL command
+				 * .. [#ht-nxt-compass-cmd1] to calibrate a sensor,
+				 *    Call the BEGIN-CAL command,
+				 *    Rotate the robot around 540-720 degrees at a speed of 1 full turn per 20 seconds,
+				 *    Call the END-CAL command.
 				 * 
 				 * @description: Begin calibration
-				 * @command1_footnote: [#ht-nxt-compass-cmd1]_
+				 * @name_footnote: [#ht-nxt-compass-cmd1]_
 				 */
 				.name = "BEGIN-CAL",
 			},
 			[1]= {
 				/**
 				 * @description: End calibration
-				 * @command2_footnote: [#ht-nxt-compass-cmd1]_
+				 * @name_footnote: [#ht-nxt-compass-cmd1]_
 				 */
 				.name = "END-CAL",
 			},

--- a/sensors/nxt_i2c_sensor_defs.c
+++ b/sensors/nxt_i2c_sensor_defs.c
@@ -815,7 +815,7 @@ const struct nxt_i2c_sensor_info nxt_i2c_sensor_defs[] = {
 				 * @value5: Sensor 5 (far right direction) signal strength (0-255)
 				 * @value5_footnote: [#ht-nxt-ir-seek-v2-mode2-value1]_
 				 * @value6: Sensor mean (0-255)
-				 * @value6_footnote: [#ht-nxt-ir-seek-v2-mode0-value0]_
+				 * @value6_footnote: [#ht-nxt-ir-seek-v2-mode2-value1]_
 				 */
 				.name = "DC-ALL",
 				.data_sets = 7,

--- a/sensors/nxt_i2c_sensor_defs.c
+++ b/sensors/nxt_i2c_sensor_defs.c
@@ -1237,14 +1237,14 @@ const struct nxt_i2c_sensor_info nxt_i2c_sensor_defs[] = {
 				 *    Call the END-CAL command.
 				 * 
 				 * @description: Begin calibration
-				 * @description_footnote: [#ht-nxt-compass-cmd1]_
+				 * @name_footnote: [#ht-nxt-compass-cmd1]_
 				 */
 				.name = "BEGIN-CAL",
 			},
 			[1]= {
 				/**
 				 * @description: End calibration
-				 * @description_footnote: [#ht-nxt-compass-cmd1]_
+				 * @name_footnote: [#ht-nxt-compass-cmd1]_
 				 */
 				.name = "END-CAL",
 			},

--- a/sensors/nxt_i2c_sensor_defs.c
+++ b/sensors/nxt_i2c_sensor_defs.c
@@ -770,9 +770,13 @@ const struct nxt_i2c_sensor_info nxt_i2c_sensor_defs[] = {
 				 *     ...
 				 *     9        Far right
 				 *    =======  =============
-				 *
+				 *	  These directions do not directly corresponds to the DC-ALL mode's 5 sensor values. 
+				 *    the even number directions are calculated in the sensor, while the odd number directions
+				 *    are measured actually measured by sensors 1-5 inside the HiTechnic NXT IRSeeker V2
+				 * 
+				 * 
 				 * @description: Direction (unmodulated)
-				 * @value0: Direction (0 to 9) These directions do not directly corresponds to the DC-ALL mode's 5 sensor values. the even number directions are calculated in the sensor (may have interference from sunlight)
+				 * @value0: Direction (0 to 9) 
 				 * @value0_footnote: [#ht-nxt-ir-seek-v2-mode0-value0]_
 				 */
 				.name = "DC",
@@ -797,17 +801,23 @@ const struct nxt_i2c_sensor_info nxt_i2c_sensor_defs[] = {
 				 * @description: All values (unmodulated)
 				 * @value0: Direction (0 to 9)
 				 * @value0_footnote: [#ht-nxt-ir-seek-v2-mode0-value0]_
-				 * @value1: Sensor 1 (far left direction) signal strength (0 to 255)
+				 * @value1: Sensor 1 (far left direction) signal strength 
+				 * (0 to 255)
 				 * @value1_footnote: [#ht-nxt-ir-seek-v2-mode2-value1]_
-				 * @value2: Sensor 2 (left-forward direction) signal strength (0 to 255)
+				 * @value2: Sensor 2 (left-forward direction) signal strength 
+				 * (0 to 255)
 				 * @value2_footnote: [#ht-nxt-ir-seek-v2-mode2-value1]_
-				 * @value3: Sensor 3 (forward direction) signal strength (0 to 255)
+				 * @value3: Sensor 3 (forward direction) signal strength 
+				 * (0 to 255)
 				 * @value3_footnote: [#ht-nxt-ir-seek-v2-mode2-value1]_
-				 * @value4: Sensor 4 (right-forward direction) signal strength (0 to 255)
+				 * @value4: Sensor 4 (right-forward direction) signal strength 
+				 * (0 to 255)
 				 * @value4_footnote: [#ht-nxt-ir-seek-v2-mode2-value1]_
-				 * @value5: Sensor 5 (far right direction) signal strength (0 to 255)
+				 * @value5: Sensor 5 (far right direction) signal strength 
+				 * (0 to 255)
 				 * @value5_footnote: [#ht-nxt-ir-seek-v2-mode2-value1]_
-				 * @value6: Sensor mean (0 to 255)
+				 * @value6: Sensor mean 
+				 * (0 to 255)
 				 * @value6_footnote: [#ht-nxt-ir-seek-v2-mode0-value0]_
 				 */
 				.name = "DC-ALL",
@@ -818,15 +828,20 @@ const struct nxt_i2c_sensor_info nxt_i2c_sensor_defs[] = {
 				 * @description: All values (modulated)
 				 * @value0: Direction (0 to 9)
 				 * @value0_footnote: [#ht-nxt-ir-seek-v2-mode0-value0]_
-				 * @value1: Sensor 1 (far left direction) signal strength (0 to 255)
+				 * @value1: Sensor 1 (far left direction) signal strength 
+				 * (0 to 255)
 				 * @value1_footnote: [#ht-nxt-ir-seek-v2-mode0-value0]_
-				 * @value2: Sensor 2 (left-forward direction) signal strength (0 to 255)
+				 * @value2: Sensor 2 (left-forward direction) signal strength 
+				 * (0 to 255)
 				 * @value2_footnote: [#ht-nxt-ir-seek-v2-mode0-value0]_
-				 * @value3: Sensor 3 (forward direction) signal strength (0 to 255)
+				 * @value3: Sensor 3 (forward direction) signal strength 
+				 * (0 to 255)
 				 * @value3_footnote: [#ht-nxt-ir-seek-v2-mode0-value0]_
-				 * @value4: Sensor 4 (right-forward direction) signal strength (0 to 255)
+				 * @value4: Sensor 4 (right-forward direction) signal strength 
+				 * (0 to 255)
 				 * @value4_footnote: [#ht-nxt-ir-seek-v2-mode0-value0]_
-				 * @value5: Sensor 5 (far right direction) signal strength (0 to 255)
+				 * @value5: Sensor 5 (far right direction) signal strength 
+				 * (0 to 255)
 				 * @value5_footnote: [#ht-nxt-ir-seek-v2-mode0-value0]_
 				 */
 				.name = "AC-ALL",

--- a/sensors/nxt_i2c_sensor_defs.c
+++ b/sensors/nxt_i2c_sensor_defs.c
@@ -801,23 +801,17 @@ const struct nxt_i2c_sensor_info nxt_i2c_sensor_defs[] = {
 				 * @description: All values (unmodulated)
 				 * @value0: Direction (0 to 9)
 				 * @value0_footnote: [#ht-nxt-ir-seek-v2-mode0-value0]_
-				 * @value1: Sensor 1 (far left direction) signal strength 
-				 * (0 to 255)
+				 * @value1: Sensor 1 (far left direction) signal strength (0-255)
 				 * @value1_footnote: [#ht-nxt-ir-seek-v2-mode2-value1]_
-				 * @value2: Sensor 2 (left-forward direction) signal strength 
-				 * (0 to 255)
+				 * @value2: Sensor 2 (left-forward direction) signal strength (0-255)
 				 * @value2_footnote: [#ht-nxt-ir-seek-v2-mode2-value1]_
-				 * @value3: Sensor 3 (forward direction) signal strength 
-				 * (0 to 255)
+				 * @value3: Sensor 3 (forward direction) signal strength (0-255)
 				 * @value3_footnote: [#ht-nxt-ir-seek-v2-mode2-value1]_
-				 * @value4: Sensor 4 (right-forward direction) signal strength 
-				 * (0 to 255)
+				 * @value4: Sensor 4 (right-forward direction) signal strength (0-255)
 				 * @value4_footnote: [#ht-nxt-ir-seek-v2-mode2-value1]_
-				 * @value5: Sensor 5 (far right direction) signal strength 
-				 * (0 to 255)
+				 * @value5: Sensor 5 (far right direction) signal strength (0-255)
 				 * @value5_footnote: [#ht-nxt-ir-seek-v2-mode2-value1]_
-				 * @value6: Sensor mean 
-				 * (0 to 255)
+				 * @value6: Sensor mean (0-255)
 				 * @value6_footnote: [#ht-nxt-ir-seek-v2-mode0-value0]_
 				 */
 				.name = "DC-ALL",
@@ -828,20 +822,15 @@ const struct nxt_i2c_sensor_info nxt_i2c_sensor_defs[] = {
 				 * @description: All values (modulated)
 				 * @value0: Direction (0 to 9)
 				 * @value0_footnote: [#ht-nxt-ir-seek-v2-mode0-value0]_
-				 * @value1: Sensor 1 (far left direction) signal strength 
-				 * (0 to 255)
+				 * @value1: Sensor 1 (far left direction) signal strength (0-255)
 				 * @value1_footnote: [#ht-nxt-ir-seek-v2-mode2-value1]_
-				 * @value2: Sensor 2 (left-forward direction) signal strength 
-				 * (0 to 255)
+				 * @value2: Sensor 2 (left-forward direction) signal strength (0-255)
 				 * @value2_footnote: [#ht-nxt-ir-seek-v2-mode2-value1]_
-				 * @value3: Sensor 3 (forward direction) signal strength 
-				 * (0 to 255)
+				 * @value3: Sensor 3 (forward direction) signal strength (0-255)
 				 * @value3_footnote: [#ht-nxt-ir-seek-v2-mode2-value1]_
-				 * @value4: Sensor 4 (right-forward direction) signal strength 
-				 * (0 to 255)
+				 * @value4: Sensor 4 (right-forward direction) signal strength (0-255)
 				 * @value4_footnote: [#ht-nxt-ir-seek-v2-mode2-value1]_
-				 * @value5: Sensor 5 (far right direction) signal strength 
-				 * (0 to 255)
+				 * @value5: Sensor 5 (far right direction) signal strength (0-255)
 				 * @value5_footnote: [#ht-nxt-ir-seek-v2-mode2-value1]_
 				 */
 				.name = "AC-ALL",

--- a/sensors/nxt_i2c_sensor_defs.c
+++ b/sensors/nxt_i2c_sensor_defs.c
@@ -791,20 +791,23 @@ const struct nxt_i2c_sensor_info nxt_i2c_sensor_defs[] = {
 			},
 			[2] = {
 				/**
+				 * .. [#ht-nxt-ir-seek-v2-mode2-value1] Signal strengths may not reach as high as 255. Strength is dependent on many factors such as IR source strength, sunlight interference etc.
+				 */
+				/**
 				 * @description: All values (unmodulated)
 				 * @value0: Direction (0 to 9)
 				 * @value0_footnote: [#ht-nxt-ir-seek-v2-mode0-value0]_
-				 * @value1: Sensor 1 (far left direction) signal strength (0 to ~130) (upper limit dependent on IR source strength).
-				 * @value1_footnote: [#ht-nxt-ir-seek-v2-mode0-value0]_
-				 * @value2: Sensor 2 (left-forward direction) signal strength (0 to ~130) (upper limit dependent on IR source strength)
-				 * @value2_footnote: [#ht-nxt-ir-seek-v2-mode0-value0]_
-				 * @value3: Sensor 3 (forward direction) signal strength (0 to ~130) (upper limit dependent on IR source strength)
-				 * @value3_footnote: [#ht-nxt-ir-seek-v2-mode0-value0]_
-				 * @value4: Sensor 4 (right-forward direction) signal strength (0 to ~130) (upper limit dependent on IR source strength)
-				 * @value4_footnote: [#ht-nxt-ir-seek-v2-mode0-value0]_
-				 * @value5: Sensor 5 (far right direction) signal strength (0 to ~130) (upper limit dependent on IR source strength)
-				 * @value5_footnote: [#ht-nxt-ir-seek-v2-mode0-value0]_
-				 * @value6: Sensor mean (0 to ~ 130) (upper limit dependent on IR source strength) (may be affected by sunlight)
+				 * @value1: Sensor 1 (far left direction) signal strength (0 to 255)
+				 * @value1_footnote: [#ht-nxt-ir-seek-v2-mode2-value1]_
+				 * @value2: Sensor 2 (left-forward direction) signal strength (0 to 255)
+				 * @value2_footnote: [#ht-nxt-ir-seek-v2-mode2-value1]_
+				 * @value3: Sensor 3 (forward direction) signal strength (0 to 255)
+				 * @value3_footnote: [#ht-nxt-ir-seek-v2-mode2-value1]_
+				 * @value4: Sensor 4 (right-forward direction) signal strength (0 to 255)
+				 * @value4_footnote: [#ht-nxt-ir-seek-v2-mode2-value1]_
+				 * @value5: Sensor 5 (far right direction) signal strength (0 to 255)
+				 * @value5_footnote: [#ht-nxt-ir-seek-v2-mode2-value1]_
+				 * @value6: Sensor mean (0 to 255)
 				 * @value6_footnote: [#ht-nxt-ir-seek-v2-mode0-value0]_
 				 */
 				.name = "DC-ALL",
@@ -815,15 +818,15 @@ const struct nxt_i2c_sensor_info nxt_i2c_sensor_defs[] = {
 				 * @description: All values (modulated)
 				 * @value0: Direction (0 to 9)
 				 * @value0_footnote: [#ht-nxt-ir-seek-v2-mode0-value0]_
-				 * @value1: Sensor 1 (far left direction) signal strength (0 to ~130) (upper limit dependent on IR source strength).
+				 * @value1: Sensor 1 (far left direction) signal strength (0 to 255)
 				 * @value1_footnote: [#ht-nxt-ir-seek-v2-mode0-value0]_
-				 * @value2: Sensor 2 (left-forward direction) signal strength (0 to ~130) (upper limit dependent on IR source strength)
+				 * @value2: Sensor 2 (left-forward direction) signal strength (0 to 255)
 				 * @value2_footnote: [#ht-nxt-ir-seek-v2-mode0-value0]_
-				 * @value3: Sensor 3 (forward direction) signal strength (0 to ~130) (upper limit dependent on IR source strength)
+				 * @value3: Sensor 3 (forward direction) signal strength (0 to 255)
 				 * @value3_footnote: [#ht-nxt-ir-seek-v2-mode0-value0]_
-				 * @value4: Sensor 4 (right-forward direction) signal strength (0 to ~130) (upper limit dependent on IR source strength)
+				 * @value4: Sensor 4 (right-forward direction) signal strength (0 to 255)
 				 * @value4_footnote: [#ht-nxt-ir-seek-v2-mode0-value0]_
-				 * @value5: Sensor 5 (far right direction) signal strength (0 to ~130) (upper limit dependent on IR source strength)
+				 * @value5: Sensor 5 (far right direction) signal strength (0 to 255)
 				 * @value5_footnote: [#ht-nxt-ir-seek-v2-mode0-value0]_
 				 */
 				.name = "AC-ALL",

--- a/sensors/nxt_i2c_sensor_defs.c
+++ b/sensors/nxt_i2c_sensor_defs.c
@@ -770,7 +770,7 @@ const struct nxt_i2c_sensor_info nxt_i2c_sensor_defs[] = {
 				 *     ...
 				 *     9        Far right
 				 *    =======  =============
-				 *	  These directions do not directly corresponds to the DC-ALL mode's 5 sensor values. 
+				 *    These directions do not directly corresponds to the DC-ALL mode's 5 sensor values. 
 				 *    the even number directions are calculated in the sensor, while the odd number directions
 				 *    are measured actually measured by sensors 1-5 inside the HiTechnic NXT IRSeeker V2
 				 * 
@@ -827,22 +827,22 @@ const struct nxt_i2c_sensor_info nxt_i2c_sensor_defs[] = {
 				/**
 				 * @description: All values (modulated)
 				 * @value0: Direction (0 to 9)
-				 * @value0_footnote: [#ht-nxt-ir-seek-v2-mode0-value0]_
+				 * @value0_footnote: [#ht-nxt-ir-seek-v2-mode2-value1]_
 				 * @value1: Sensor 1 (far left direction) signal strength 
 				 * (0 to 255)
-				 * @value1_footnote: [#ht-nxt-ir-seek-v2-mode0-value0]_
+				 * @value1_footnote: [#ht-nxt-ir-seek-v2-mode2-value1]_
 				 * @value2: Sensor 2 (left-forward direction) signal strength 
 				 * (0 to 255)
-				 * @value2_footnote: [#ht-nxt-ir-seek-v2-mode0-value0]_
+				 * @value2_footnote: [#ht-nxt-ir-seek-v2-mode2-value1]_
 				 * @value3: Sensor 3 (forward direction) signal strength 
 				 * (0 to 255)
-				 * @value3_footnote: [#ht-nxt-ir-seek-v2-mode0-value0]_
+				 * @value3_footnote: [#ht-nxt-ir-seek-v2-mode2-value1]_
 				 * @value4: Sensor 4 (right-forward direction) signal strength 
 				 * (0 to 255)
-				 * @value4_footnote: [#ht-nxt-ir-seek-v2-mode0-value0]_
+				 * @value4_footnote: [#ht-nxt-ir-seek-v2-mode2-value1]_
 				 * @value5: Sensor 5 (far right direction) signal strength 
 				 * (0 to 255)
-				 * @value5_footnote: [#ht-nxt-ir-seek-v2-mode0-value0]_
+				 * @value5_footnote: [#ht-nxt-ir-seek-v2-mode2-value1]_
 				 */
 				.name = "AC-ALL",
 				.data_sets = 6,


### PR DESCRIPTION
Since the [HiTechnic website](http://www.hitechnic.com/cgi-bin/commerce.cgi?preadd=action&key=NMC1034) that contains information for this sensor seems to have gone missing, I've found [this](https://mindboards.org/viewtopic.php?t=940) method that works for calibrating the HiTechnic NXT Compass Sensor. This Pull request adds a footnote to the `BEGIN-CAL` and `END-CAL`  commands. Here's a preview of what it will look like https://irseeker-temporary-lego-linux-drivers.readthedocs.io/en/latest/sensor_data.html#ht-nxt-compass This is just for helping people figure out how to calibrate the sensor (I spent way too much finding a way to calibrate them before I found that forum post)